### PR TITLE
Update Redis version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upperkut (0.4.6)
+    upperkut (0.4.5)
       redis (>= 3.3.3, < 5)
 
 GEM

--- a/lib/upperkut/version.rb
+++ b/lib/upperkut/version.rb
@@ -1,3 +1,3 @@
 module Upperkut
-  VERSION = '0.4.6'.freeze
+  VERSION = '0.4.5'.freeze
 end


### PR DESCRIPTION
- Increasing version range for Redis from 3.3.5/5 to 3.3.3/5