### PR TITLE
Enable users to pass ConnectionPool object on strategy setup

### DIFF
--- a/lib/upperkut/strategy.rb
+++ b/lib/upperkut/strategy.rb
@@ -9,7 +9,8 @@ module Upperkut
 
     def initialize(worker, options = {})
       @options    = options
-      @redis_pool = RedisPool.new(options.fetch(:redis, {})).create
+      @redis_options = options.fetch(:redis, {})
+      @redis_pool = setup_redis_pool
       @worker     = worker
     end
 
@@ -52,6 +53,11 @@ module Upperkut
     end
 
     private
+
+    def setup_redis_pool
+      return @redis_options if @redis_options.is_a?(ConnectionPool)
+      RedisPool.new(options.fetch(:redis, {})).create
+    end
 
     def redis
       raise ArgumentError, "requires a block" unless block_given?


### PR DESCRIPTION
Now users can pass a ConnectionPool object rather than a redis URL:

```
class MyWorker
  include Upperkut::Worker

  setup_upperkut do |config|
    pool = ConnectionPool.new(:timeout => 3, :size => 200) do
        Redis.new
    end

    config.strategy = Upperkut::Strategy(self, redis: pool)
  end

  def perform(items)
  end
end
```

The old scenario keep working:

```
class MyWorker
  include Upperkut::Worker

  setup_upperkut do |config|
    config.strategy = Upperkut::Strategy(self, redis: { url: ENV['REDIS_URL'] })
  end

  def perform(items)
  end
end
```

This satisfies issue #20 