### PR TITLE
adds the possibility to customize timeout

### DIFF
--- a/lib/upperkut/cli.rb
+++ b/lib/upperkut/cli.rb
@@ -63,7 +63,7 @@ module Upperkut
         )
 
         manager.stop
-        sleep(5)
+        sleep(Integer(ENV['UPPERKUT_TIMEOUT'] || 8))
         manager.kill
         exit(0)
       end


### PR DESCRIPTION
This PR enable users to customize timeout (number of seconds should be wait for the current job to finish) when the process receives a TERM or INT.