### PR TITLE
Add priority queue strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            gem install bundler -v 2.0.1
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            gem install bundler
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            gem install bundler
+            gem install bundler -v 2.0.1
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in upperkut.gemspec
 gemspec
 
-gem 'fakeredis'
 gem 'fivemat'
 gem 'pry'
 gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   2.0.1
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     upperkut (0.7.2)
       connection_pool (~> 2.2, >= 2.2.2)
-      redis (>= 3.3.3, < 5)
+      redis (>= 4.1.0, < 5.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,29 +12,27 @@ GEM
     connection_pool (2.2.2)
     diff-lcs (1.3)
     docile (1.3.1)
-    fakeredis (0.7.0)
-      redis (>= 3.2, < 5.0)
-    fivemat (1.3.6)
-    json (2.1.0)
-    method_source (0.9.0)
-    pry (0.11.3)
+    fivemat (1.3.7)
+    json (2.2.0)
+    method_source (0.9.2)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    redis (4.0.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    redis (4.1.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     simplecov (0.16.1)
@@ -47,8 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
-  fakeredis
+  bundler (>= 1.16)
   fivemat
   pry
   rake (~> 10.0)
@@ -58,4 +55,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   1.16.6
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upperkut (0.7.2)
+    upperkut (0.7.3)
       connection_pool (~> 2.2, >= 2.2.2)
       redis (>= 4.1.0, < 5.0.0)
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,52 @@ Or install it yourself as:
   $ bundle exec upperkut --worker MyWorker --concurrency 10
   ```
 
+### Example 2 - Priority Queue:
+
+Note: priority queues requires redis 5.0.0+ as it uses ZPOP* commands.
+
+1) Create a Worker class and the define how to process the batch;
+  ```ruby
+  require 'upperkut/strategies/priority_queue'
+
+  class MyWorker
+    include Upperkut::Worker
+
+    setup_upperkut do |config|
+      config.strategy = Upperkut::Strategies::PriorityQueue.new(
+        self,
+        priority_key: lambda { |item| item['tenant_id'] }
+      )
+    end
+
+    def perform(items)
+      items.each do |item|
+        puts "event dispatched: #{item.inspect}"
+      end
+    end
+  end
+  ```
+
+2) So you can enqueue items from different tenants;
+  ```ruby
+  MyWorker.push_items(
+    [
+      { 'tenant_id' => 1, 'id' => 1 },
+      { 'tenant_id' => 1, 'id' => 2 },
+      { 'tenant_id' => 1, 'id' => 3 },
+      { 'tenant_id' => 2, 'id' => 4 },
+      { 'tenant_id' => 3, 'id' => 5 },
+    ]
+  )
+  ```
+
+  The code above will enqueue items as follows `1, 4, 5, 2, 3`
+
+3) Start Upperkut;
+  ```bash
+  $ bundle exec upperkut --worker MyWorker --concurrency 10
+  ```
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `bundle exec rspec` to run the tests.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Or install it yourself as:
   $ bundle exec upperkut --worker MyWorker --concurrency 10
   ```
 
-### Example 2 - Priority Queue:
+### Example 3 - Priority Queue:
 
 Note: priority queues requires redis 5.0.0+ as it uses ZPOP* commands.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Or install it yourself as:
   Myworker.push_items(
     [
       {
-        'id' => SecureRandom.uuid, 
-        'name' => 'Robert C Hall', 
+        'id' => SecureRandom.uuid,
+        'name' => 'Robert C Hall',
         'action' => 'EMAIL_OPENNED'
       }
     ]
@@ -83,9 +83,9 @@ Or install it yourself as:
   Myworker.push_items(
     [
       {
-        'timestamp' => '1557531838', 
-        'id' => SecureRandom.uuid, 
-        'name' => 'Robert C Hall', 
+        'timestamp' => '1557531838',
+        'id' => SecureRandom.uuid,
+        'name' => 'Robert C Hall',
         'action' => 'SEND_NOTIFICATION'
       }
     ]

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Note: priority queues requires redis 5.0.0+ as it uses ZPOP* commands.
     setup_upperkut do |config|
       config.strategy = Upperkut::Strategies::PriorityQueue.new(
         self,
-        priority_key: lambda { |item| item['tenant_id'] }
+        priority_key: -> { |item| item['tenant_id'] }
       )
     end
 

--- a/examples/priority_worker.rb
+++ b/examples/priority_worker.rb
@@ -7,7 +7,7 @@ class PriorityWorker
   setup_upperkut do |config|
     config.strategy = Upperkut::Strategies::PriorityQueue.new(
       self,
-      priority_key: lambda { |item| item['tenant_id'] },
+      priority_key: -> { |item| item['tenant_id'] },
       batch_size: 200
     )
   end

--- a/examples/priority_worker.rb
+++ b/examples/priority_worker.rb
@@ -8,13 +8,14 @@ class PriorityWorker
     config.strategy = Upperkut::Strategies::PriorityQueue.new(
       self,
       priority_key: -> { |item| item['tenant_id'] },
-      batch_size: 200
+      batch_size: 1
     )
   end
 
   def perform(items)
     items.each do |item|
       puts "event dispatched: #{item.inspect}"
+      sleep 1
     end
   end
 end

--- a/examples/priority_worker.rb
+++ b/examples/priority_worker.rb
@@ -1,0 +1,20 @@
+require_relative '../lib/upperkut/worker'
+require_relative '../lib/upperkut/strategies/priority_queue'
+
+class PriorityWorker
+  include Upperkut::Worker
+
+  setup_upperkut do |config|
+    config.strategy = Upperkut::Strategies::PriorityQueue.new(
+      self,
+      priority_key: lambda { |item| item['tenant_id'] },
+      batch_size: 200
+    )
+  end
+
+  def perform(items)
+    items.each do |item|
+      puts "event dispatched: #{item.inspect}"
+    end
+  end
+end

--- a/lib/upperkut/redis_pool.rb
+++ b/lib/upperkut/redis_pool.rb
@@ -9,11 +9,11 @@ module Upperkut
       connect_timeout: 0.2,
       read_timeout: 5.0,
       write_timeout: 0.5,
-      url: ENV['REDIS_URL']
     }.freeze
 
     def initialize(options)
-      @options      = DEFAULT_OPTIONS.merge(options)
+      @options      = DEFAULT_OPTIONS.merge(url: ENV['REDIS_URL'])
+                                     .merge(options)
 
       # Extract pool related options
       @size         = @options.delete(:size)

--- a/lib/upperkut/redis_pool.rb
+++ b/lib/upperkut/redis_pool.rb
@@ -8,7 +8,7 @@ module Upperkut
       size: 2, # pool related option
       connect_timeout: 0.2,
       read_timeout: 5.0,
-      write_timeout: 0.5,
+      write_timeout: 0.5
     }.freeze
 
     def initialize(options)

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -12,7 +12,6 @@ module Upperkut
       def initialize(worker, options = {})
         @options = options
         @redis_options = options.fetch(:redis, {})
-        @redis_pool = setup_redis_pool
         @worker     = worker
         @max_wait   = options.fetch(
           :max_wait,
@@ -99,7 +98,7 @@ module Upperkut
       def setup_redis_pool
         return @redis_options if @redis_options.is_a?(ConnectionPool)
 
-        RedisPool.new(options.fetch(:redis, {})).create
+        RedisPool.new(@redis_options).create
       end
 
       def redis
@@ -108,6 +107,13 @@ module Upperkut
         @redis_pool.with do |conn|
           yield conn
         end
+      end
+
+      def redis_pool
+        @redis_pool ||= begin
+                          return @redis_options if @redis_options.is_a?(ConnectionPool)
+                          RedisPool.new(options.fetch(:redis, {})).create
+                        end
       end
 
       def key

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -105,8 +105,11 @@ module Upperkut
 
       def redis_pool
         @redis_pool ||= begin
-                          return @redis_options if @redis_options.is_a?(ConnectionPool)
-                          RedisPool.new(@redis_options).create
+                          if @redis_options.is_a?(ConnectionPool)
+                            @redis_options
+                          else
+                            RedisPool.new(@redis_options).create
+                          end
                         end
       end
 

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -95,16 +95,10 @@ module Upperkut
         now - item.fetch('enqueued_at', Time.now).to_f
       end
 
-      def setup_redis_pool
-        return @redis_options if @redis_options.is_a?(ConnectionPool)
-
-        RedisPool.new(@redis_options).create
-      end
-
       def redis
         raise ArgumentError, 'requires a block' unless block_given?
 
-        @redis_pool.with do |conn|
+        redis_pool.with do |conn|
           yield conn
         end
       end
@@ -112,7 +106,7 @@ module Upperkut
       def redis_pool
         @redis_pool ||= begin
                           return @redis_options if @redis_options.is_a?(ConnectionPool)
-                          RedisPool.new(options.fetch(:redis, {})).create
+                          RedisPool.new(@redis_options).create
                         end
       end
 

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -74,6 +74,10 @@ module Upperkut
 
       private
 
+      def key
+        "upperkut:buffers:#{to_underscore(@worker.name)}"
+      end
+
       def fulfill_condition?(buff_size)
         return false if buff_size.zero?
 
@@ -111,10 +115,6 @@ module Upperkut
                             RedisPool.new(@redis_options).create
                           end
                         end
-      end
-
-      def key
-        "upperkut:buffers:#{to_underscore(@worker.name)}"
       end
     end
   end

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -4,6 +4,8 @@ module Upperkut
     class PriorityQueue < Upperkut::Strategies::Base
       include Upperkut::Util
 
+      ONE_DAY_IN_SECONDS = 86400
+
       # Logic as follows:
       #
       # We keep the last score used for each tenant key. One tenant_key is
@@ -33,7 +35,7 @@ module Upperkut
           next_score = current_checkpoint + increment
         end
 
-        redis.call("SETEX", score_key, 86400, next_score)
+        redis.call("SETEX", score_key, #{ONE_DAY_IN_SECONDS}, next_score)
         redis.call("ZADD", queue_key, next_score, ARGV[1])
 
         return next_score

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -18,12 +18,9 @@ module Upperkut
       #  sends few messages to have a fair share of processing time
       ENQUEUE_ITEM = %(
         local increment = 1
-
         local current_checkpoint = tonumber(redis.call("GET", KEYS[1])) or 0
-
         local account_score_key = KEYS[2]
         local current_account_score = tonumber(redis.call("GET", account_score_key)) or 0
-
         local queue_key = KEYS[3]
         local next_score = nil
 
@@ -44,7 +41,6 @@ module Upperkut
         local checkpoint_key = KEYS[1]
         local queue_key = KEYS[2]
         local batch_size = ARGV[1]
-
         local popped_items = redis.call("ZPOPMIN", queue_key, batch_size)
         local items = {}
         local last_score = 0

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -178,9 +178,12 @@ module Upperkut
 
       def redis_pool
         @redis_pool ||= begin
-                         return @redis_options if @redis_options.is_a?(ConnectionPool)
-                         RedisPool.new(@options.fetch(:redis, {})).create
-                       end
+                          if @redis_options.is_a?(ConnectionPool)
+                            @redis_options
+                          else
+                            RedisPool.new(@options.fetch(:redis, {})).create
+                          end
+                        end
       end
     end
   end

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -123,7 +123,7 @@ module Upperkut
 
       # Public: Clear all data related to the strategy.
       def clear
-        redis { |conn| conn.del(key) }
+        redis { |conn| conn.del(queue_key) }
       end
 
       # Public: Tells when to execute the event processing,

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -150,17 +150,17 @@ module Upperkut
 
       private
 
-      def fulfill_condition?(buff_size)
-        return false if buff_size.zero?
-        buff_size >= @batch_size || @waiting_time >= @max_wait
-      end
-
       def queue_checkpoint_key
         "#{queue_key}:checkpoint"
       end
 
       def queue_key
         "upperkut:priority_queue:#{to_underscore(@worker.name)}"
+      end
+
+      def fulfill_condition?(buff_size)
+        return false if buff_size.zero?
+        buff_size >= @batch_size || @waiting_time >= @max_wait
       end
 
       def size

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -144,7 +144,6 @@ module Upperkut
       # Returns hash containing metric name and values.
       def metrics
         {
-          'latency' => latency,
           'size'    => size
         }
       end
@@ -168,17 +167,6 @@ module Upperkut
         redis do |conn|
           conn.zcard(queue_key)
         end
-      end
-
-      def latency
-=begin
-        item = redis { |conn| conn.lrange(key, 0, 0) }
-        item = decode_json_items(item).first
-        return 0 unless item
-        now = Time.now.to_f
-        now - item.fetch('enqueued_at', Time.now).to_f
-=end
-        0
       end
 
       def redis

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -170,7 +170,7 @@ module Upperkut
       end
 
       def redis
-        raise ArgumentError, "requires a block" unless block_given?
+        raise ArgumentError, 'requires a block' unless block_given?
         redis_pool.with do |conn|
           yield conn
         end

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -3,20 +3,19 @@ module Upperkut
     class PriorityQueue < Upperkut::Strategies::Base
       include Upperkut::Util
 
-      # Logic as follows
+      # Logic as follows:
       #
-      # we keep the last score used for each account key. One account_key is an account unique id.
-      # to calculate the next_score we use max(current_account_score, current_global_score) + increment
-      # we store the queue in a sorted set using the next_score as ordering key
-      # if one account sends lots of messages, this account ends up with lots of
-      # messages in the queue spaced by increment
-      # if another account then sends a message, since it previous_account_score is lower than the
-      # first account, it will be inserted before it in the queue
+      # We keep the last score used for each account key. One account_key is an account unique id.
+      #  to calculate the next_score we use max(current_account_score, current_global_score) + increment
+      #  we store the queue in a sorted set using the next_score as ordering key
+      #  if one account sends lots of messages, this account ends up with lots of
+      #  messages in the queue spaced by increment
+      #  if another account then sends a message, since it previous_account_score is lower than the
+      #  first account, it will be inserted before it in the queue
       #
       # In other words, the idea of this queue is to not allowing an account that sends a
-      # lot of messages to dominate processing and give a chance for accounts that
-      # sends few messages to have a fair share of processing time
-      #
+      #  lot of messages to dominate processing and give a chance for accounts that
+      #  sends few messages to have a fair share of processing time
       ENQUEUE_ITEM = %(
         local increment = 1
 
@@ -40,6 +39,7 @@ module Upperkut
         return next_score
       ).freeze
 
+      # Uses ZPOP* functions available only on redis 5.0.0+
       DEQUEUE_ITEM = %(
         local checkpoint_key = KEYS[1]
         local queue_key = KEYS[2]

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -1,0 +1,199 @@
+module Upperkut
+  module Strategies
+    class PriorityQueue < Upperkut::Strategies::Base
+      include Upperkut::Util
+
+      # Logic as follows
+      #
+      # we keep the last score used for each account key. One account_key is an account unique id.
+      # to calculate the next_score we use max(current_account_score, current_global_score) + increment
+      # we store the queue in a sorted set using the next_score as ordering key
+      # if one account sends lots of messages, this account ends up with lots of
+      # messages in the queue spaced by increment
+      # if another account then sends a message, since it previous_account_score is lower than the
+      # first account, it will be inserted before it in the queue
+      #
+      # In other words, the idea of this queue is to not allowing an account that sends a
+      # lot of messages to dominate processing and give a chance for accounts that
+      # sends few messages to have a fair share of processing time
+      #
+      ENQUEUE_ITEM = %(
+        local increment = 1
+
+        local current_checkpoint = tonumber(redis.call("GET", KEYS[1])) or 0
+
+        local account_score_key = KEYS[2]
+        local current_account_score = tonumber(redis.call("GET", account_score_key)) or 0
+
+        local queue_key = KEYS[3]
+        local next_score = nil
+
+        if current_account_score >= current_checkpoint then
+          next_score = current_account_score + increment
+        else
+          next_score = current_checkpoint + increment
+        end
+
+        redis.call("SETEX", account_score_key, 86400, next_score)
+        redis.call("ZADD", queue_key, next_score, ARGV[1])
+
+        return next_score
+      ).freeze
+
+      DEQUEUE_ITEM = %(
+        local checkpoint_key = KEYS[1]
+        local queue_key = KEYS[2]
+        local batch_size = ARGV[1]
+
+        local popped_items = redis.call("ZPOPMIN", queue_key, batch_size)
+        local items = {}
+        local last_score = 0
+
+        for i, v in ipairs(popped_items) do
+          if i % 2 == 1 then
+            table.insert(items, v)
+          else
+            last_score = v
+          end
+        end
+
+        redis.call("SETEX", checkpoint_key, 86400, last_score)
+        return items
+      ).freeze
+
+      def initialize(worker, options)
+        @worker = worker
+        @options = options
+        @priority_key = options.fetch(:priority_key)
+        @redis_options = options.fetch(:redis, {})
+
+        @max_wait   = options.fetch(
+          :max_wait,
+          Integer(ENV['UPPERKUT_MAX_WAIT'] || 20)
+        )
+
+        @batch_size = options.fetch(
+          :batch_size,
+          Integer(ENV['UPPERKUT_BATCH_SIZE'] || 1000)
+        )
+
+        @waiting_time = 0
+
+        raise ArgumentError, 'Invalid priority_key. ' \
+          'Must be a lambda' unless @priority_key.respond_to?(:call)
+      end
+
+      # Public: Ingests the event into strategy.
+      #
+      # items - The Array of items do be inserted.
+      #
+      # Returns true when success, raise when error.
+      def push_items(items = [])
+        items = [items] if items.is_a?(Hash)
+        return false if items.empty?
+
+        redis do |conn|
+          items.each do |item|
+            account_key = @priority_key.call(item)
+            account_score_key = "#{queue_key}:#{account_key}:score"
+
+            conn.eval(ENQUEUE_ITEM,
+                      keys: [queue_checkpoint_key, account_score_key, queue_key],
+                      argv: [encode_json_items([item])])
+          end
+        end
+
+        true
+      end
+
+      # Public: Retrieve events from Strategy.
+      #
+      # Returns an Array containing events as hash.
+      def fetch_items
+        batch_size = [@batch_size, size].min
+
+        items = redis do |conn|
+          conn.eval(DEQUEUE_ITEM,
+                    keys: [queue_checkpoint_key, queue_key],
+                    argv: [batch_size])
+        end
+
+        decode_json_items(items)
+      end
+
+      # Public: Clear all data related to the strategy.
+      def clear
+        redis { |conn| conn.del(key) }
+      end
+
+      # Public: Tells when to execute the event processing,
+      # when this condition is met so the events are dispatched to
+      # the worker.
+      def process?
+        if fulfill_condition?(size)
+          @waiting_time = 0
+          return true
+        end
+
+        @waiting_time += @worker.setup.polling_interval
+        false
+      end
+
+      # Public: Consolidated strategy metrics.
+      #
+      # Returns hash containing metric name and values.
+      def metrics
+        {
+          'latency' => latency,
+          'size'    => size
+        }
+      end
+
+      private
+
+      def fulfill_condition?(buff_size)
+        return false if buff_size.zero?
+        buff_size >= @batch_size || @waiting_time >= @max_wait
+      end
+
+      def queue_checkpoint_key
+        "#{queue_key}:checkpoint"
+      end
+
+      def queue_key
+        "upperkut:priority_queue:#{to_underscore(@worker.name)}"
+      end
+
+      def size
+        redis do |conn|
+          conn.zcard(queue_key)
+        end
+      end
+
+      def latency
+=begin
+        item = redis { |conn| conn.lrange(key, 0, 0) }
+        item = decode_json_items(item).first
+        return 0 unless item
+        now = Time.now.to_f
+        now - item.fetch('enqueued_at', Time.now).to_f
+=end
+        0
+      end
+
+      def redis
+        raise ArgumentError, "requires a block" unless block_given?
+        redis_pool.with do |conn|
+          yield conn
+        end
+      end
+
+      def redis_pool
+        @redis_pool ||= begin
+                         return @redis_options if @redis_options.is_a?(ConnectionPool)
+                         RedisPool.new(@options.fetch(:redis, {})).create
+                       end
+      end
+    end
+  end
+end

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -67,7 +67,7 @@ module Upperkut
         @priority_key = options.fetch(:priority_key)
         @redis_options = options.fetch(:redis, {})
 
-        @max_wait   = options.fetch(
+        @max_wait = options.fetch(
           :max_wait,
           Integer(ENV['UPPERKUT_MAX_WAIT'] || 20)
         )
@@ -144,7 +144,7 @@ module Upperkut
       # Returns hash containing metric name and values.
       def metrics
         {
-          'size'    => size
+          'size' => size
         }
       end
 

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -6,18 +6,18 @@ module Upperkut
 
       # Logic as follows:
       #
-      # We keep the last score used for each account key. One account_key is
-      #  an account unique id. To calculate the next_score we use
-      #  max(current_account_score, current_global_score) + increment we store
+      # We keep the last score used for each tenant key. One tenant_key is
+      #  an tenant unique id. To calculate the next_score we use
+      #  max(current_tenant_score, current_global_score) + increment we store
       #  the queue in a sorted set using the next_score as ordering key if one
-      #  account sends lots of messages, this account ends up with lots of
-      #  messages in the queue spaced by increment if another account then
-      #  sends a message, since it previous_account_score is lower than the
-      #  first account, it will be inserted before it in the queue.
+      #  tenant sends lots of messages, this tenant ends up with lots of
+      #  messages in the queue spaced by increment if another tenant then
+      #  sends a message, since it previous_tenant_score is lower than the
+      #  first tenant, it will be inserted before it in the queue.
       #
-      # In other words, the idea of this queue is to not allowing an account
+      # In other words, the idea of this queue is to not allowing an tenant
       #  that sends a lot of messages to dominate processing and give a chance
-      #  for accounts that sends few messages to have a fair share of
+      #  for tenants that sends few messages to have a fair share of
       #  processing time.
       ENQUEUE_ITEM = %(
         local increment = 1

--- a/lib/upperkut/version.rb
+++ b/lib/upperkut/version.rb
@@ -1,3 +1,3 @@
 module Upperkut
-  VERSION = '0.7.2'.freeze
+  VERSION = '0.7.3'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   redis = Redis.new(url: ENV['REDIS_URL'])
   # redis.select(15)
 
-  config.before(:all) { redis.flushdb }
+  config.before(:each) { redis.flushdb }
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,13 @@
-require 'simplecov'
 require 'bundler/setup'
+require 'simplecov'
 require 'redis'
 require 'pry'
+require 'upperkut'
 
 # Set default REDIS_URL environment variable
 ENV['REDIS_URL'] = 'redis://localhost'
 
 SimpleCov.start if ENV['COVERAGE'] == 'true'
-
-require 'upperkut'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -16,6 +15,11 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  redis = Redis.new(url: ENV['REDIS_URL'])
+  # redis.select(15)
+
+  config.before(:all) { redis.flushdb }
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   redis = Redis.new(url: ENV['REDIS_URL'])
-  # redis.select(15)
 
   config.before(:each) { redis.flushdb }
 

--- a/spec/upperkut/redis_pool_spec.rb
+++ b/spec/upperkut/redis_pool_spec.rb
@@ -2,22 +2,31 @@ require 'spec_helper'
 
 module Upperkut
   RSpec.describe RedisPool do
-    describe '.initialize' do
+    describe '#create' do
+      subject(:pool) { described_class.new(options).create }
+
       context 'when giving redis URL' do
-        let(:options) { { redis: { url: 'another.redis.url' } } }
+        let(:options) do
+          { url: 'redis://another.redis.url' }
+        end
 
         it 'creates RedisPool with specific URL' do
-          expect(RedisPool.new(options.fetch(:redis, {})).instance_variable_get(:@options)[:url])
-            .to eq(options[:redis][:url])
+          pool.with do |redis|
+            expect(redis.connection[:host]).to eq('another.redis.url')
+          end
         end
       end
 
       context 'whithout giving redis URL' do
-        let(:options) { { redis: {} } }
+        let(:options) { {} }
 
         it 'creates RedisPool with REDIS_URL env' do
-          expect(RedisPool.new(options.fetch(:redis, {})).instance_variable_get(:@options)[:url])
-            .to eq(ENV['REDIS_URL'])
+          # avoids side-effects by stubing env instead of setting it
+          allow(ENV).to receive(:[]).with('REDIS_URL').and_return('redis://my-default-redis')
+
+          pool.with do |redis|
+            expect(redis.connection[:host]).to eq('my-default-redis')
+          end
         end
       end
     end

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -8,6 +8,10 @@ module Upperkut
       # DummyWorker class to use in tests
       class DummyWorker
         include Upperkut::Worker
+
+        setup_upperkut do |config|
+          config.strategy = strategy
+        end
       end
 
       subject(:strategy) { described_class.new(DummyWorker) }

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'upperkut/strategies/priority_queue'
+require 'time'
+
+module Upperkut
+  module Strategies
+    RSpec.describe PriorityQueue do
+      # DummyWorker class to use in tests
+      class DummyWorker
+        include Upperkut::Worker
+      end
+
+      subject(:strategy) { described_class.new(DummyWorker) }
+
+      before do
+        strategy.clear
+      end
+
+      describe '.push_items' do
+        it 'insert items in the queue' do
+          expect do
+            strategy.push_items([{ 'event' => 'open' }, { 'event' => 'click' }])
+          end.to change { strategy.metrics['size'] }.from(0).to(2)
+        end
+
+        it 'insert items in the tail' do
+          strategy.push_items([{ 'event' => 'open' }])
+          strategy.push_items('event' => 'click')
+
+          items = strategy.fetch_items.collect do |item|
+            item['body']
+          end
+
+          expect(items.last).to eq('event' => 'click')
+        end
+
+        context 'when items isn\'t a array' do
+          it 'inserts item in the queue' do
+            expect do
+              strategy.push_items('event' => 'open', 'k' => 1)
+            end.to change { strategy.metrics['size'] }.from(0).to(1)
+          end
+        end
+      end
+
+      describe '.fetch_items' do
+        it 'returns the head items off queue' do
+          strategy.push_items([{ 'event' => 'open' }, { 'event' => 'click' }])
+
+          items = strategy.fetch_items.collect do |item|
+            item['body']
+          end
+
+          expect(items).to eq([{ 'event' => 'open' }, { 'event' => 'click' }])
+        end
+      end
+
+      describe '.latency' do
+        it 'returns correct latency' do
+          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
+          strategy.push_items('event' => 'open', 'k' => 1)
+
+          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:04'))
+          strategy.push_items('event' => 'open', 'k' => 1)
+
+          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:10'))
+
+          expect(strategy.metrics['latency']).to eq 10.0
+        end
+      end
+
+      describe '.clear' do
+        it 'deletes the queue' do
+          strategy.push_items(['event' => 'open'])
+          expect do
+            strategy.clear
+          end.to change { strategy.metrics['size'] }.from(1).to(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -70,6 +70,21 @@ module Upperkut
           end.to change { strategy.metrics['size'] }.from(1).to(0)
         end
       end
+
+      describe '.metrics' do
+        it 'returns the number of items to be processed' do
+          strategy.push_items([
+            {'tenant_id' => 1, 'some_text' => 'item 1.1'},
+            {'tenant_id' => 1, 'some_text' => 'item 1.2'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.1'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.2'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.1'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.2'},
+          ])
+
+          expect(strategy.metrics['size']).to eq(6)
+        end
+      end
     end
   end
 end

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -28,7 +28,6 @@ module Upperkut
 
       describe '.push_items' do
         # TODO: uma fila não impacta a outra
-        # TODO: clear limpa a fila
 
         it 'avoids contiguous priority keys' do
           strategy.push_items([

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -23,7 +23,7 @@ module Upperkut
       end
 
       before do
-        # strategy.clear
+        strategy.clear
       end
 
       describe '.push_items' do
@@ -58,6 +58,16 @@ module Upperkut
             {'tenant_id' => 2, 'some_text' => 'item 2.2'},
             {'tenant_id' => 3, 'some_text' => 'item 3.2'},
           ])
+        end
+      end
+
+      describe '.clear' do
+        it 'deletes the queue' do
+          strategy.push_items(['tenant_id' => 1, 'event' => 'open'])
+
+          expect do
+            strategy.clear
+          end.to change { strategy.metrics['size'] }.from(1).to(0)
         end
       end
     end

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -27,8 +27,6 @@ module Upperkut
       end
 
       describe '.push_items' do
-        # TODO: uma fila não impacta a outra
-
         it 'avoids contiguous priority keys' do
           strategy.push_items([
             {'tenant_id' => 1, 'some_text' => 'item 1.1'},

--- a/upperkut.gemspec
+++ b/upperkut.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.2'
 
   spec.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
-  spec.add_dependency 'redis',           '>= 3.3.3', '< 5'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_dependency 'redis', '>= 4.1.0', '< 5.0.0'
+  spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
Implements https://github.com/ResultadosDigitais/upperkut/issues/27.

Add a strategy to prevent one tenant from taking over the queue. The strategy uses an algorithm that ensures a valid fraction of time to each tenant.

You can learn more about the algorithm [here](https://github.com/ResultadosDigitais/upperkut/pull/39/files#diff-c2d6390b6a15519a1096419828ca1676R6).