### PR TITLE
Implementing handle_error method to the worker classes

### DIFF
--- a/lib/upperkut/batch_execution.rb
+++ b/lib/upperkut/batch_execution.rb
@@ -20,7 +20,7 @@ module Upperkut
       @worker.server_middlewares.invoke(@worker, items) do
         worker_instance.perform(items_body.dup)
       end
-    rescue Exception => ex
+    rescue StandardError => ex
       @logger.info(
         action: :requeue,
         ex: ex,
@@ -31,7 +31,7 @@ module Upperkut
 
       if worker_instance.respond_to?(:handle_error)
         worker_instance.handle_error(ex, items_body)
-        return 
+        return
       else
         @worker.push_items(items_body)
       end

--- a/lib/upperkut/batch_execution.rb
+++ b/lib/upperkut/batch_execution.rb
@@ -20,23 +20,23 @@ module Upperkut
       @worker.server_middlewares.invoke(@worker, items) do
         worker_instance.perform(items_body.dup)
       end
-    rescue StandardError => ex
+    rescue StandardError => error
       @logger.info(
         action: :requeue,
-        ex: ex,
+        ex: error,
         item_size: items_body.size
       )
 
-      @logger.error(ex.backtrace.join("\n"))
+      @logger.error(error.backtrace.join("\n"))
 
       if worker_instance.respond_to?(:handle_error)
-        worker_instance.handle_error(ex, items_body)
+        worker_instance.handle_error(error, items_body)
         return
       else
         @worker.push_items(items_body)
       end
 
-      raise ex
+      raise error
     end
   end
 end

--- a/lib/upperkut/batch_execution.rb
+++ b/lib/upperkut/batch_execution.rb
@@ -21,8 +21,6 @@ module Upperkut
         worker_instance.perform(items_body.dup)
       end
     rescue Exception => ex
-      @worker.push_items(items_body)
-
       @logger.info(
         action: :requeue,
         ex: ex,
@@ -30,6 +28,14 @@ module Upperkut
       )
 
       @logger.error(ex.backtrace.join("\n"))
+
+      if worker_instance.respond_to?(:handle_error)
+        worker_instance.handle_error(ex, items_body)
+        return 
+      else
+        @worker.push_items(items_body)
+      end
+
       raise ex
     end
   end

--- a/spec/upperkut/batch_execution_spec.rb
+++ b/spec/upperkut/batch_execution_spec.rb
@@ -3,6 +3,14 @@ require 'upperkut/batch_execution'
 
 module Upperkut
   RSpec.describe BatchExecution do
+    class SmarterWorker
+      include Worker
+
+      def perform(_items); end
+
+      def handle_error(_exception, _items); end
+    end
+
     class DummyWorker
       include Worker
 
@@ -11,24 +19,43 @@ module Upperkut
 
     around do |example|
       DummyWorker.clear
+      SmarterWorker.clear
       example.run
       DummyWorker.clear
+      SmarterWorker.clear
     end
 
     let(:worker) { DummyWorker }
-
+    let(:smarter_worker) { SmarterWorker }
+    
     context 'when something goes wrong while processing' do
-      it 'requeue_item' do
-        allow_any_instance_of(worker).to receive(:perform).and_raise(ArgumentError)
+      context 'when client implements handle_error method' do
+        it 'calls .handle_error method' do 
+          allow_any_instance_of(smarter_worker).to receive(:perform).and_raise(ArgumentError)
+  
+          item = { 'id' => '1', 'event' => 'open' }
+          smarter_worker.push_items(item)
+  
+          execution = BatchExecution.new(smarter_worker)
+          expect_any_instance_of(smarter_worker).to receive(:handle_error)
 
-        item = { 'id' => '1', 'event' => 'open' }
-        worker.push_items(item)
+          expect { execution.execute }.not_to raise_error(ArgumentError)
+        end
+      end
 
-        expect(worker.metrics['size']).to eq 1
-
-        execution = BatchExecution.new(worker)
-        expect { execution.execute }.to raise_error(ArgumentError)
-        expect(worker.metrics['size']).to eq 1
+      context 'when client doesnt implement handle_error method' do
+        it 'requeue_item' do
+          allow_any_instance_of(worker).to receive(:perform).and_raise(ArgumentError)
+  
+          item = { 'id' => '1', 'event' => 'open' }
+          worker.push_items(item)
+  
+          expect(worker.metrics['size']).to eq 1
+  
+          execution = BatchExecution.new(worker)
+          expect { execution.execute }.to raise_error(ArgumentError)
+          expect(worker.metrics['size']).to eq 1
+        end  
       end
     end
   end


### PR DESCRIPTION
This PR allows worker classes to implement a method called handle_method.

During the processing, if a exception occours, the processor will check if that method is defined.
When it is present, the processor will call it. When it isn't, the items will be requeued.