### PR TITLE
Create middleware server configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 0.7.x
 ---------
+- Add handle_error method #44
+- Added Datahog Middleware (#42)
+- Added Priority Queue (#39) thanks to @jeangnc and @jeanmatheussouto
 - Added Scheduled Queue Implementation thanks to @rodrigo-araujo #38
 - Added Datahog middleware #42 by @gabriel-augusto
 - Added redis to CI #40 by #henrich-m

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in upperkut.gemspec
 gemspec
 
-gem 'fakeredis'
 gem 'fivemat'
 gem 'pry'
 gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    upperkut (0.7.2)
+    upperkut (0.7.3)
       connection_pool (~> 2.2, >= 2.2.2)
-      redis (>= 3.3.3, < 5)
+      redis (>= 4.1.0, < 5.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,29 +12,27 @@ GEM
     connection_pool (2.2.2)
     diff-lcs (1.3)
     docile (1.3.1)
-    fakeredis (0.7.0)
-      redis (>= 3.2, < 5.0)
-    fivemat (1.3.6)
-    json (2.1.0)
-    method_source (0.9.0)
-    pry (0.11.3)
+    fivemat (1.3.7)
+    json (2.2.0)
+    method_source (0.9.2)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    redis (4.0.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    redis (4.1.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     simplecov (0.16.1)
@@ -47,8 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
-  fakeredis
+  bundler (>= 1.16)
   fivemat
   pry
   rake (~> 10.0)
@@ -58,4 +55,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upperkut (0.7.3)
+    upperkut (0.7.4)
       connection_pool (~> 2.2, >= 2.2.2)
       redis (>= 4.1.0, < 5.0.0)
 

--- a/examples/priority_worker.rb
+++ b/examples/priority_worker.rb
@@ -1,0 +1,21 @@
+require_relative '../lib/upperkut/worker'
+require_relative '../lib/upperkut/strategies/priority_queue'
+
+class PriorityWorker
+  include Upperkut::Worker
+
+  setup_upperkut do |config|
+    config.strategy = Upperkut::Strategies::PriorityQueue.new(
+      self,
+      priority_key: -> { |item| item['tenant_id'] },
+      batch_size: 1
+    )
+  end
+
+  def perform(items)
+    items.each do |item|
+      puts "event dispatched: #{item.inspect}"
+      sleep 1
+    end
+  end
+end

--- a/lib/config/configuration.rb
+++ b/lib/config/configuration.rb
@@ -1,0 +1,10 @@
+module Upperkut
+  class Configuration
+    attr_accessor :server_middlewares, :client_middlewares
+    
+    def initialize
+      @server_middlewares = []
+      @client_middlewares = []
+    end
+  end
+end

--- a/lib/upperkut/redis_pool.rb
+++ b/lib/upperkut/redis_pool.rb
@@ -8,12 +8,12 @@ module Upperkut
       size: 2, # pool related option
       connect_timeout: 0.2,
       read_timeout: 5.0,
-      write_timeout: 0.5,
-      url: ENV['REDIS_URL']
+      write_timeout: 0.5
     }.freeze
 
     def initialize(options)
-      @options      = DEFAULT_OPTIONS.merge(options)
+      @options      = DEFAULT_OPTIONS.merge(url: ENV['REDIS_URL'])
+                                     .merge(options)
 
       # Extract pool related options
       @size         = @options.delete(:size)

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -1,0 +1,197 @@
+module Upperkut
+  module Strategies
+    # Public: Queue that prevent a single tenant from taking over.
+    class PriorityQueue < Upperkut::Strategies::Base
+      include Upperkut::Util
+
+      ONE_DAY_IN_SECONDS = 86400
+
+      # Logic as follows:
+      #
+      # We keep the last score used for each tenant key. One tenant_key is
+      #  an tenant unique id. To calculate the next_score we use
+      #  max(current_tenant_score, current_global_score) + increment we store
+      #  the queue in a sorted set using the next_score as ordering key if one
+      #  tenant sends lots of messages, this tenant ends up with lots of
+      #  messages in the queue spaced by increment if another tenant then
+      #  sends a message, since it previous_tenant_score is lower than the
+      #  first tenant, it will be inserted before it in the queue.
+      #
+      # In other words, the idea of this queue is to not allowing an tenant
+      #  that sends a lot of messages to dominate processing and give a chance
+      #  for tenants that sends few messages to have a fair share of
+      #  processing time.
+      ENQUEUE_ITEM = %(
+        local increment = 1
+        local current_checkpoint = tonumber(redis.call("GET", KEYS[1])) or 0
+        local score_key = KEYS[2]
+        local current_score = tonumber(redis.call("GET", score_key)) or 0
+        local queue_key = KEYS[3]
+        local next_score = nil
+
+        if current_score >= current_checkpoint then
+          next_score = current_score + increment
+        else
+          next_score = current_checkpoint + increment
+        end
+
+        redis.call("SETEX", score_key, #{ONE_DAY_IN_SECONDS}, next_score)
+        redis.call("ZADD", queue_key, next_score, ARGV[1])
+
+        return next_score
+      ).freeze
+
+      # Uses ZPOP* functions available only on redis 5.0.0+
+      DEQUEUE_ITEM = %(
+        local checkpoint_key = KEYS[1]
+        local queue_key = KEYS[2]
+        local batch_size = ARGV[1]
+        local popped_items = redis.call("ZPOPMIN", queue_key, batch_size)
+        local items = {}
+        local last_score = 0
+
+        for i, v in ipairs(popped_items) do
+          if i % 2 == 1 then
+            table.insert(items, v)
+          else
+            last_score = v
+          end
+        end
+
+        redis.call("SETEX", checkpoint_key, 86400, last_score)
+        return items
+      ).freeze
+
+      def initialize(worker, options)
+        @worker = worker
+        @options = options
+        @priority_key = options.fetch(:priority_key)
+        @redis_options = options.fetch(:redis, {})
+
+        @max_wait = options.fetch(
+          :max_wait,
+          Integer(ENV['UPPERKUT_MAX_WAIT'] || 20)
+        )
+
+        @batch_size = options.fetch(
+          :batch_size,
+          Integer(ENV['UPPERKUT_BATCH_SIZE'] || 1000)
+        )
+
+        @waiting_time = 0
+
+        raise ArgumentError, 'Invalid priority_key. ' \
+          'Must be a lambda' unless @priority_key.respond_to?(:call)
+      end
+
+      # Public: Ingests the event into strategy.
+      #
+      # items - The Array of items do be inserted.
+      #
+      # Returns true when success, raise when error.
+      def push_items(items = [])
+        items = [items] if items.is_a?(Hash)
+        return false if items.empty?
+
+        redis do |conn|
+          items.each do |item|
+            priority_key = @priority_key.call(item)
+            score_key = "#{queue_key}:#{priority_key}:score"
+
+            keys = [queue_checkpoint_key,
+                    score_key,
+                    queue_key]
+
+            conn.eval(ENQUEUE_ITEM,
+                      keys: keys,
+                      argv: [encode_json_items([item])])
+          end
+        end
+
+        true
+      end
+
+      # Public: Retrieve events from Strategy.
+      #
+      # Returns an Array containing events as hash.
+      def fetch_items
+        batch_size = [@batch_size, size].min
+
+        items = redis do |conn|
+          conn.eval(DEQUEUE_ITEM,
+                    keys: [queue_checkpoint_key, queue_key],
+                    argv: [batch_size])
+        end
+
+        decode_json_items(items)
+      end
+
+      # Public: Clear all data related to the strategy.
+      def clear
+        redis { |conn| conn.del(queue_key) }
+      end
+
+      # Public: Tells when to execute the event processing,
+      # when this condition is met so the events are dispatched to
+      # the worker.
+      def process?
+        if fulfill_condition?(size)
+          @waiting_time = 0
+          return true
+        end
+
+        @waiting_time += @worker.setup.polling_interval
+        false
+      end
+
+      # Public: Consolidated strategy metrics.
+      #
+      # Returns hash containing metric name and values.
+      def metrics
+        {
+          'size' => size
+        }
+      end
+
+      private
+
+      def queue_checkpoint_key
+        "#{queue_key}:checkpoint"
+      end
+
+      def queue_key
+        "upperkut:priority_queue:#{to_underscore(@worker.name)}"
+      end
+
+      def fulfill_condition?(buff_size)
+        return false if buff_size.zero?
+
+        buff_size >= @batch_size || @waiting_time >= @max_wait
+      end
+
+      def size
+        redis do |conn|
+          conn.zcard(queue_key)
+        end
+      end
+
+      def redis
+        raise ArgumentError, 'requires a block' unless block_given?
+
+        redis_pool.with do |conn|
+          yield conn
+        end
+      end
+
+      def redis_pool
+        @redis_pool ||= begin
+                          if @redis_options.is_a?(ConnectionPool)
+                            @redis_options
+                          else
+                            RedisPool.new(@options.fetch(:redis, {})).create
+                          end
+                        end
+      end
+    end
+  end
+end

--- a/lib/upperkut/version.rb
+++ b/lib/upperkut/version.rb
@@ -1,3 +1,3 @@
 module Upperkut
-  VERSION = '0.7.3'.freeze
+  VERSION = '0.7.4'.freeze
 end

--- a/lib/upperkut/version.rb
+++ b/lib/upperkut/version.rb
@@ -1,3 +1,3 @@
 module Upperkut
-  VERSION = '0.7.2'.freeze
+  VERSION = '0.7.3'.freeze
 end

--- a/lib/upperkut/worker.rb
+++ b/lib/upperkut/worker.rb
@@ -33,7 +33,7 @@ module Upperkut
       def setup
         @config ||=
           begin
-            config = Upperkut::Configuration.default.clone
+            config = Upperkut::WorkerConfiguration.default.clone
             config.strategy ||= Upperkut::Strategies::BufferedQueue.new(self)
             config
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,13 @@
-require 'simplecov'
 require 'bundler/setup'
+require 'simplecov'
 require 'redis'
 require 'pry'
+require 'upperkut'
 
 # Set default REDIS_URL environment variable
 ENV['REDIS_URL'] = 'redis://localhost'
 
 SimpleCov.start if ENV['COVERAGE'] == 'true'
-
-require 'upperkut'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -16,6 +15,10 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  redis = Redis.new(url: ENV['REDIS_URL'])
+
+  config.before(:each) { redis.flushdb }
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/upperkut/batch_execution_spec.rb
+++ b/spec/upperkut/batch_execution_spec.rb
@@ -3,6 +3,14 @@ require 'upperkut/batch_execution'
 
 module Upperkut
   RSpec.describe BatchExecution do
+    class SmarterWorker
+      include Worker
+
+      def perform(_items); end
+
+      def handle_error(_exception, _items); end
+    end
+
     class DummyWorker
       include Worker
 
@@ -11,24 +19,43 @@ module Upperkut
 
     around do |example|
       DummyWorker.clear
+      SmarterWorker.clear
       example.run
       DummyWorker.clear
+      SmarterWorker.clear
     end
 
     let(:worker) { DummyWorker }
-
+    let(:smarter_worker) { SmarterWorker }
+    
     context 'when something goes wrong while processing' do
-      it 'requeue_item' do
-        allow_any_instance_of(worker).to receive(:perform).and_raise(ArgumentError)
+      context 'when client implements handle_error method' do
+        it 'calls .handle_error method' do 
+          allow_any_instance_of(smarter_worker).to receive(:perform).and_raise(ArgumentError)
+  
+          item = { 'id' => '1', 'event' => 'open' }
+          smarter_worker.push_items(item)
+  
+          execution = BatchExecution.new(smarter_worker)
+          expect_any_instance_of(smarter_worker).to receive(:handle_error)
 
-        item = { 'id' => '1', 'event' => 'open' }
-        worker.push_items(item)
+          expect { execution.execute }.not_to raise_error(ArgumentError)
+        end
+      end
 
-        expect(worker.metrics['size']).to eq 1
-
-        execution = BatchExecution.new(worker)
-        expect { execution.execute }.to raise_error(ArgumentError)
-        expect(worker.metrics['size']).to eq 1
+      context 'when client doesnt implement handle_error method' do
+        it 'requeue_item' do
+          allow_any_instance_of(worker).to receive(:perform).and_raise(ArgumentError)
+  
+          item = { 'id' => '1', 'event' => 'open' }
+          worker.push_items(item)
+  
+          expect(worker.metrics['size']).to eq 1
+  
+          execution = BatchExecution.new(worker)
+          expect { execution.execute }.to raise_error(ArgumentError)
+          expect(worker.metrics['size']).to eq 1
+        end  
       end
     end
   end

--- a/spec/upperkut/redis_pool_spec.rb
+++ b/spec/upperkut/redis_pool_spec.rb
@@ -2,22 +2,31 @@ require 'spec_helper'
 
 module Upperkut
   RSpec.describe RedisPool do
-    describe '.initialize' do
+    describe '#create' do
+      subject(:pool) { described_class.new(options).create }
+
       context 'when giving redis URL' do
-        let(:options) { { redis: { url: 'another.redis.url' } } }
+        let(:options) do
+          { url: 'redis://another.redis.url' }
+        end
 
         it 'creates RedisPool with specific URL' do
-          expect(RedisPool.new(options.fetch(:redis, {})).instance_variable_get(:@options)[:url])
-            .to eq(options[:redis][:url])
+          pool.with do |redis|
+            expect(redis.connection[:host]).to eq('another.redis.url')
+          end
         end
       end
 
       context 'whithout giving redis URL' do
-        let(:options) { { redis: {} } }
+        let(:options) { {} }
 
         it 'creates RedisPool with REDIS_URL env' do
-          expect(RedisPool.new(options.fetch(:redis, {})).instance_variable_get(:@options)[:url])
-            .to eq(ENV['REDIS_URL'])
+          # avoids side-effects by stubing env instead of setting it
+          allow(ENV).to receive(:[]).with('REDIS_URL').and_return('redis://my-default-redis')
+
+          pool.with do |redis|
+            expect(redis.connection[:host]).to eq('my-default-redis')
+          end
         end
       end
     end

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -8,6 +8,10 @@ module Upperkut
       # DummyWorker class to use in tests
       class DummyWorker
         include Upperkut::Worker
+
+        setup_upperkut do |config|
+          config.strategy = strategy
+        end
       end
 
       subject(:strategy) { described_class.new(DummyWorker) }

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'upperkut/strategies/priority_queue'
+require 'time'
+
+module Upperkut
+  module Strategies
+    RSpec.describe PriorityQueue do
+      # DummyWorker class to use in tests
+      class DummyWorker
+        include Upperkut::Worker
+
+        setup_upperkut do |config|
+          config.strategy = strategy
+        end
+      end
+
+      subject(:strategy) do
+        options = {
+          priority_key: lambda { |item| item['tenant_id'] }
+        }
+
+        described_class.new(DummyWorker, options)
+      end
+
+      before do
+        strategy.clear
+      end
+
+      describe '.push_items' do
+        it 'avoids contiguous priority keys' do
+          strategy.push_items([
+            {'tenant_id' => 1, 'some_text' => 'item 1.1'},
+            {'tenant_id' => 1, 'some_text' => 'item 1.2'},
+          ])
+
+          strategy.push_items([
+            {'tenant_id' => 2, 'some_text' => 'item 2.1'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.2'},
+          ])
+
+          strategy.push_items([
+            {'tenant_id' => 3, 'some_text' => 'item 3.1'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.2'},
+          ])
+
+          items = strategy.fetch_items.collect do |item|
+            item['body']
+          end
+
+          expect(items).to eq([
+            {'tenant_id' => 1, 'some_text' => 'item 1.1'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.1'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.1'},
+            {'tenant_id' => 1, 'some_text' => 'item 1.2'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.2'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.2'},
+          ])
+        end
+      end
+
+      describe '.clear' do
+        it 'deletes the queue' do
+          strategy.push_items(['tenant_id' => 1, 'event' => 'open'])
+
+          expect do
+            strategy.clear
+          end.to change { strategy.metrics['size'] }.from(1).to(0)
+        end
+      end
+
+      describe '.metrics' do
+        it 'returns the number of items to be processed' do
+          strategy.push_items([
+            {'tenant_id' => 1, 'some_text' => 'item 1.1'},
+            {'tenant_id' => 1, 'some_text' => 'item 1.2'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.1'},
+            {'tenant_id' => 2, 'some_text' => 'item 2.2'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.1'},
+            {'tenant_id' => 3, 'some_text' => 'item 3.2'},
+          ])
+
+          expect(strategy.metrics['size']).to eq(6)
+        end
+      end
+    end
+  end
+end

--- a/spec/upperkut_spec.rb
+++ b/spec/upperkut_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 require 'upperkut'
 
-RSpec.describe Upperkut::Configuration do
+RSpec.describe Upperkut::WorkerConfiguration do
   class MyMiddleware
     def call(_worker, _items); end
   end
 
   describe '.default' do
     it 'return an upperkut configuration values as default' do
-      default = Upperkut::Configuration.default
+      default = Upperkut::WorkerConfiguration.default
 
       expect(default.polling_interval).to eq 5
     end
   end
 
   describe '#server_middlewares' do
-    let(:config) { Upperkut::Configuration.default }
+    let(:config) { Upperkut::WorkerConfiguration.default }
 
     context 'when block is given' do
       it 'yields the current server middlewares configuration and return it' do
@@ -38,7 +38,7 @@ RSpec.describe Upperkut::Configuration do
   end
 
   describe '#client_middlewares' do
-    let(:config) { Upperkut::Configuration.default }
+    let(:config) { Upperkut::WorkerConfiguration.default }
 
     context 'when block is given' do
       it 'yields the current client middlewares configuration and return it' do

--- a/upperkut.gemspec
+++ b/upperkut.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.2'
 
   spec.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
-  spec.add_dependency 'redis',           '>= 3.3.3', '< 5'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_dependency 'redis', '>= 4.1.0', '< 5.0.0'
+  spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
This PR allow global middlewares configuration, to avoid inline changes to add new middlewares.

Ex.:
```
Upperkut.config do |config| 
  config.server_middlewares.push(MyServerMiddleware)
  config.server_middlewares.push(MyOtherServerMiddleware)

  config.client_middlewares.push(MyClientMiddleware)
  config.client_middlewares.push(MyOtherClientMiddleware)
end
```