### PR TITLE
Allow global middlewares configuration

### DIFF
--- a/lib/config/configuration.rb
+++ b/lib/config/configuration.rb
@@ -1,10 +1,10 @@
 module Upperkut
   # Allows global configuration like below:
-  # 
-  # Upperkut.config do |config| 
+  #
+  # Upperkut.config do |config|
   #   config.server_middlewares.push(MyServerMiddleware)
   #   config.server_middlewares.push(MyOtherServerMiddleware)
-  # 
+  #
   #   config.client_middlewares.push(MyClientMiddleware)
   #   config.client_middlewares.push(MyOtherClientMiddleware)
   # end

--- a/lib/config/configuration.rb
+++ b/lib/config/configuration.rb
@@ -1,0 +1,19 @@
+module Upperkut
+  # Allows global configuration like below:
+  # 
+  # Upperkut.config do |config| 
+  #   config.server_middlewares.push(MyServerMiddleware)
+  #   config.server_middlewares.push(MyOtherServerMiddleware)
+  # 
+  #   config.client_middlewares.push(MyClientMiddleware)
+  #   config.client_middlewares.push(MyOtherClientMiddleware)
+  # end
+  class Configuration
+    attr_accessor :server_middlewares, :client_middlewares
+
+    def initialize
+      @server_middlewares = []
+      @client_middlewares = []
+    end
+  end
+end

--- a/lib/upperkut.rb
+++ b/lib/upperkut.rb
@@ -54,7 +54,7 @@ require 'redis'
 #
 # 4) That's it :)
 module Upperkut
-  # Upperkut.config do |config| 
+  # Upperkut.config do |config|
   #   config.server_middlewares.push(MyServerMiddleware)
   #   config.server_middlewares.push(MyClientMiddleware)
   # end
@@ -67,12 +67,13 @@ module Upperkut
     end
   end
 
+  # Defines the configuration of each worker
   class WorkerConfiguration
     attr_accessor :strategy, :polling_interval
 
     def self.default
-      Upperkut.config if Upperkut.server_configuration.nil?
-      
+      Upperkut.config unless Upperkut.server_configuration
+
       new.tap do |config|
         config.polling_interval = Integer(ENV['UPPERKUT_POLLING_INTERVAL'] || 5)
       end

--- a/lib/upperkut.rb
+++ b/lib/upperkut.rb
@@ -1,5 +1,6 @@
 require_relative 'upperkut/version'
 require_relative 'upperkut/worker'
+require_relative 'config/configuration'
 require 'redis'
 
 # Public: Upperkut is a batch background processing tool for Ruby.
@@ -53,10 +54,25 @@ require 'redis'
 #
 # 4) That's it :)
 module Upperkut
-  class Configuration
+  # Upperkut.config do |config| 
+  #   config.server_middlewares.push(MyServerMiddleware)
+  #   config.server_middlewares.push(MyClientMiddleware)
+  # end
+  class << self
+    attr_accessor :server_configuration
+
+    def config
+      @server_configuration ||= Upperkut::Configuration.new
+      yield(@server_configuration) if block_given?
+    end
+  end
+
+  class WorkerConfiguration
     attr_accessor :strategy, :polling_interval
 
     def self.default
+      Upperkut.config if Upperkut.server_configuration.nil?
+      
       new.tap do |config|
         config.polling_interval = Integer(ENV['UPPERKUT_POLLING_INTERVAL'] || 5)
       end
@@ -69,7 +85,7 @@ module Upperkut
     end
 
     def client_middlewares
-      @client_middlewares ||= Middleware::Chain.new
+      @client_middlewares ||= init_client_middleware_chain
       yield @client_middlewares if block_given?
       @client_middlewares
     end
@@ -92,6 +108,20 @@ module Upperkut
       if defined?(Datadog)
         require_relative 'upperkut/middlewares/datadog'
         chain.add(Upperkut::Middlewares::Datadog)
+      end
+
+      Upperkut.server_configuration.server_middlewares.each do |server_middleware|
+        chain.add(server_middleware)
+      end
+
+      chain
+    end
+
+    def init_client_middleware_chain
+      chain = Middleware::Chain.new
+
+      Upperkut.server_configuration.client_middlewares.each do |client_middleware|
+        chain.add(client_middleware)
       end
 
       chain

--- a/lib/upperkut/worker.rb
+++ b/lib/upperkut/worker.rb
@@ -33,7 +33,7 @@ module Upperkut
       def setup
         @config ||=
           begin
-            config = Upperkut::Configuration.default.clone
+            config = Upperkut::WorkerConfiguration.default.clone
             config.strategy ||= Upperkut::Strategies::BufferedQueue.new(self)
             config
           end

--- a/spec/upperkut_spec.rb
+++ b/spec/upperkut_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 require 'upperkut'
 
-RSpec.describe Upperkut::Configuration do
+RSpec.describe Upperkut::WorkerConfiguration do
   class MyMiddleware
     def call(_worker, _items); end
   end
 
   describe '.default' do
     it 'return an upperkut configuration values as default' do
-      default = Upperkut::Configuration.default
+      default = Upperkut::WorkerConfiguration.default
 
       expect(default.polling_interval).to eq 5
     end
   end
 
   describe '#server_middlewares' do
-    let(:config) { Upperkut::Configuration.default }
+    let(:config) { Upperkut::WorkerConfiguration.default }
 
     context 'when block is given' do
       it 'yields the current server middlewares configuration and return it' do
@@ -38,7 +38,7 @@ RSpec.describe Upperkut::Configuration do
   end
 
   describe '#client_middlewares' do
-    let(:config) { Upperkut::Configuration.default }
+    let(:config) { Upperkut::WorkerConfiguration.default }
 
     context 'when block is given' do
       it 'yields the current client middlewares configuration and return it' do


### PR DESCRIPTION
This PR allow global middlewares configuration.

Ex.:
```
Upperkut.config do |config| 
  config.server_middlewares.push(MyServerMiddleware)
  config.server_middlewares.push(MyOtherServerMiddleware)

  config.client_middlewares.push(MyClientMiddleware)
  config.client_middlewares.push(MyOtherClientMiddleware)
end
```