### PR TITLE
Add exponential backoff

### DIFF
--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -182,8 +182,10 @@ module Upperkut
       def redis
         raise ArgumentError, 'requires a block' unless block_given?
 
-        redis_pool.with do |conn|
-          yield conn
+        retry_block do
+          redis_pool.with do |conn|
+            yield conn
+          end
         end
       end
 

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -144,6 +144,7 @@ module Upperkut
                             RedisPool.new(@redis_options).create
                           end
                         end
+      end
     end
   end
 end

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -126,12 +126,6 @@ module Upperkut
         now_timestamp - job['timestamp'].to_f
       end
 
-      def setup_redis_pool
-        return @redis_options if @redis_options.is_a?(ConnectionPool)
-
-        RedisPool.new(options.fetch(:redis, {})).create
-      end
-
       def redis
         raise ArgumentError, 'requires a block' unless block_given?
 

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -36,5 +36,22 @@ module Upperkut
         memo << Item.from_json(item) if item
       end
     end
+
+    def retry_block(retries_limit = 3, base_sleep = 2)
+      retries = 0
+
+      begin
+        yield
+      rescue StandardError => e
+        if retries < retries_limit
+          retries += 1
+          sleep_time = base_sleep ** retries
+          Kernel.sleep(sleep_time)
+          retry
+        end
+
+        raise
+      end
+    end
   end
 end

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -42,15 +42,15 @@ module Upperkut
 
       begin
         yield
-      rescue StandardError => e
+      rescue StandardError => err
         if retries < retries_limit
           retries += 1
-          sleep_time = base_sleep ** retries
+          sleep_time = base_sleep**retries
           Kernel.sleep(sleep_time)
           retry
         end
 
-        raise
+        raise err
       end
     end
   end


### PR DESCRIPTION
All network communication is expected to fail transiently and so, we must deal with eventual failures on every strategy, where now is critical to ensure all operations get performed successfully.

On this PR we introduce a `retry_block` function that will seamlessly retry a given block using exponential backoff till it reaches its limit.