### PR TITLE
prevent error when fetch_items raise an exception

### DIFF
--- a/lib/upperkut/batch_execution.rb
+++ b/lib/upperkut/batch_execution.rb
@@ -18,13 +18,14 @@ module Upperkut
         worker_instance.perform(items_body.dup)
       end
     rescue StandardError => error
-      @logger.info(
-        action: :requeue,
-        ex: error,
-        item_size: items.size
+      @logger.error(
+        action: :handle_execution_error,
+        ex: error.to_s,
+        backtrace: error.backtrace.join("\n"),
+        item_size: Array(items).size
       )
 
-      @logger.error(error.backtrace.join("\n"))
+     raise unless items
 
       if worker_instance.respond_to?(:handle_error)
         worker_instance.handle_error(error, items_body)

--- a/spec/upperkut/batch_execution_spec.rb
+++ b/spec/upperkut/batch_execution_spec.rb
@@ -28,7 +28,7 @@ module Upperkut
     let(:worker) { DummyWorker }
     let(:smarter_worker) { SmarterWorker }
 
-    context 'when something goes wrong while fetching items', :wip do
+    context 'when something goes wrong while fetching items' do
       it 'it logs correctly' do
         allow(DummyWorker).to receive(:fetch_items).and_raise(ArgumentError)
 


### PR DESCRIPTION
if fetch_items raise an exception the rescue guard
was trying to push them back if though there were no
items to push.