### PR TITLE
Add message acknowledgement mechanism

### DIFF
--- a/lib/upperkut/processor.rb
+++ b/lib/upperkut/processor.rb
@@ -5,7 +5,7 @@ module Upperkut
     def initialize(worker, logger = Logging.logger)
       @worker = worker
       @strategy = worker.strategy
-      @worker_instance = @worker.new
+      @worker_instance = worker.new
       @logger = logger
     end
 

--- a/lib/upperkut/strategies/base.rb
+++ b/lib/upperkut/strategies/base.rb
@@ -24,6 +24,20 @@ module Upperkut
         raise NotImplementedError
       end
 
+      # Public: Confirms that items have been processed successfully.
+      #
+      # items - The Array of items do be confirmed.
+      def ack(_items)
+        raise NotImplementedError
+      end
+
+      # Public: Informs that items have been not processed successfully and therefore must be re-processed.
+      #
+      # items - The Array of items do be unacknowledged.
+      def nack(_items)
+        raise NotImplementedError
+      end
+
       # Public: Tells when to execute the event processing,
       # when this condition is met so the events are dispatched to
       # the worker.

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -105,7 +105,7 @@ module Upperkut
         redis { |conn| conn.del(key) }
       end
 
-      def ack(items);
+      def ack(items)
         raise ArgumentError, 'Invalid item' unless items.all?(Item)
 
         redis do |conn|

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -7,13 +7,45 @@ module Upperkut
     class BufferedQueue < Upperkut::Strategies::Base
       include Upperkut::Util
 
+      DEQUEUE_ITEM = %(
+        local key = KEYS[1]
+        local waiting_ack_key = KEYS[2]
+        local batch_size = ARGV[1]
+        local current_timestamp = ARGV[2]
+        local expired_ack_timestamp = ARGV[3] + 1
+
+        -- move expired items back to the queue
+        local expired_ack_items = redis.call("ZRANGEBYSCORE", waiting_ack_key, 0, expired_ack_timestamp)
+        if table.getn(expired_ack_items) > 0 then
+          redis.call("ZREMRANGEBYSCORE", waiting_ack_key, 0, expired_ack_timestamp)
+          for i, item in ipairs(expired_ack_items) do
+            redis.call("RPUSH", key, item)
+          end
+        end
+
+        -- now fetch a batch
+        local items = redis.call("LRANGE", key, 0, batch_size - 1)
+        for i, item in ipairs(items) do
+          redis.call("ZADD", waiting_ack_key, current_timestamp + tonumber('0.' .. i), item)
+        end
+        redis.call("LTRIM", key, batch_size, -1)
+
+        return items
+      ).freeze
+
       attr_reader :options
 
       def initialize(worker, options = {})
         @options = options
         @redis_options = options.fetch(:redis, {})
-        @worker     = worker
-        @max_wait   = options.fetch(
+        @worker = worker
+
+        @ack_wait_limit = options.fetch(
+          :ack_wait_limit,
+          60
+        )
+
+        @max_wait = options.fetch(
           :max_wait,
           Integer(ENV['UPPERKUT_MAX_WAIT'] || 20)
         )
@@ -38,12 +70,12 @@ module Upperkut
       end
 
       def fetch_items
-        stop = [@batch_size, size].min
+        batch_size = [@batch_size, size].min
 
         items = redis do |conn|
-          conn.multi do
-            stop.times { conn.lpop(key) }
-          end
+          conn.eval(DEQUEUE_ITEM,
+                    keys: [key, processing_key],
+                    argv: [batch_size, Time.now.utc.to_i, Time.now.utc.to_i - @ack_wait_limit])
         end
 
         decode_json_items(items)
@@ -82,6 +114,10 @@ module Upperkut
 
       def key
         "upperkut:buffers:#{to_underscore(@worker.name)}"
+      end
+
+      def processing_key
+        "#{key}:processing"
       end
 
       def fulfill_condition?(buff_size)

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -53,11 +53,10 @@ module Upperkut
         redis { |conn| conn.del(key) }
       end
 
-      def metrics
-        {
-          'latency' => latency,
-          'size' => size
-        }
+      def ack(_items); end
+
+      def nack(items)
+        push_items(items)
       end
 
       def process?
@@ -70,6 +69,13 @@ module Upperkut
           @waiting_time += @worker.setup.polling_interval
           return false
         end
+      end
+
+      def metrics
+        {
+          'latency' => latency,
+          'size' => size
+        }
       end
 
       private

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -106,7 +106,7 @@ module Upperkut
       end
 
       def ack(items)
-        raise ArgumentError, 'Invalid item' unless items.all?(Item)
+        raise ArgumentError, 'Invalid item' unless items.all? { |item| item.is_a?(Item) }
 
         redis do |conn|
           conn.eval(ACK_ITEMS,
@@ -116,7 +116,7 @@ module Upperkut
       end
 
       def nack(items)
-        raise ArgumentError, 'Invalid item' unless items.all?(Item)
+        raise ArgumentError, 'Invalid item' unless items.all? { |item| item.is_a?(Item) }
 
         redis do |conn|
           conn.eval(NACK_ITEMS,

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -139,6 +139,12 @@ module Upperkut
         redis { |conn| conn.del(queue_key) }
       end
 
+      def ack(_items); end
+
+      def nack(items)
+        push_items(items)
+      end
+
       # Public: Tells when to execute the event processing,
       # when this condition is met so the events are dispatched to
       # the worker.

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -70,6 +70,12 @@ module Upperkut
         redis { |conn| conn.del(key) }
       end
 
+      def ack(_items); end
+
+      def nack(items)
+        push_items(items)
+      end
+
       def metrics
         {
           'latency' => latency,

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,8 @@
+require 'time'
+
+module Helpers
+  def travel_to(time)
+    allow(Time).to receive(:now).and_return(time)
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'simplecov'
 require 'redis'
 require 'pry'
 require 'upperkut'
+require_relative 'helpers'
 
 # Set default REDIS_URL environment variable
 ENV['REDIS_URL'] = 'redis://localhost'
@@ -17,10 +18,11 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   redis = Redis.new(url: ENV['REDIS_URL'])
-
   config.before(:each) { redis.flushdb }
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include Helpers
 end

--- a/spec/support/in_memory_strategy.rb
+++ b/spec/support/in_memory_strategy.rb
@@ -1,0 +1,42 @@
+require 'upperkut/util'
+
+class InMemoryStrategy
+  include Upperkut::Util
+
+  attr_reader :items, :processing
+
+  def initialize
+    @items = []
+    @processing = []
+  end
+
+  def push_items(items)
+    @items.concat(normalize_items(items))
+  end
+
+  def fetch_items
+    @items.slice!(0..10)
+  end
+
+  def ack(items)
+  end
+
+  def nack(items)
+  end
+
+  def clear
+    @items.clear
+  end
+
+  def process?
+    true
+  end
+
+  def metrics
+    {
+      'size' => @items.size,
+      'latency' => Time.now.to_i - @items.first.enqueued_at
+    }
+  end
+end
+

--- a/spec/upperkut/processor_spec.rb
+++ b/spec/upperkut/processor_spec.rb
@@ -1,44 +1,14 @@
 require 'spec_helper'
-require 'upperkut/util'
+require 'support/in_memory_strategy'
 require 'upperkut/processor'
 
 module Upperkut
   RSpec.describe Processor do
     subject(:processor) { described_class.new(worker, logger) }
 
+    let(:strategy) { worker.strategy }
     let(:worker) { DummyWorker }
     let(:logger) { Logger.new(nil) }
-
-    class InMemoryStrategy
-      include Util
-
-      def initialize
-        @items = []
-      end
-
-      def push_items(items)
-        @items.concat(normalize_items(items))
-      end
-
-      def fetch_items
-        @items.slice!(0..10)
-      end
-
-      def clear
-        @items.clear
-      end
-
-      def process?
-        true
-      end
-
-      def metrics
-        {
-          'size' => @items.size,
-          'latency' => Time.now.to_i - @items.first.enqueued_at
-        }
-      end
-    end
 
     class DummyWorker
       include Worker

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -5,6 +5,8 @@ require 'time'
 module Upperkut
   module Strategies
     RSpec.describe BufferedQueue do
+      subject(:strategy) { described_class.new(DummyWorker) }
+
       # DummyWorker class to use in tests
       class DummyWorker
         include Upperkut::Worker
@@ -13,8 +15,6 @@ module Upperkut
           config.strategy = strategy
         end
       end
-
-      subject(:strategy) { described_class.new(DummyWorker) }
 
       before do
         strategy.clear

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -20,7 +20,7 @@ module Upperkut
         strategy.clear
       end
 
-      describe '.push_items' do
+      describe '#push_items' do
         it 'insert items in the queue' do
           expect do
             strategy.push_items([{ 'event' => 'open' }, { 'event' => 'click' }])
@@ -45,7 +45,7 @@ module Upperkut
         end
       end
 
-      describe '.fetch_items' do
+      describe '#fetch_items' do
         it 'returns the head items off queue' do
           strategy.push_items([{ 'event' => 'open' }, { 'event' => 'click' }])
 
@@ -55,7 +55,7 @@ module Upperkut
         end
       end
 
-      describe '.latency' do
+      describe '#latency' do
         it 'returns correct latency' do
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
           strategy.push_items('event' => 'open', 'k' => 1)
@@ -69,7 +69,7 @@ module Upperkut
         end
       end
 
-      describe '.clear' do
+      describe '#clear' do
         it 'deletes the queue' do
           strategy.push_items(['event' => 'open'])
           expect do

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -5,7 +5,9 @@ require 'time'
 module Upperkut
   module Strategies
     RSpec.describe BufferedQueue do
-      subject(:strategy) { described_class.new(DummyWorker) }
+      subject(:strategy) { described_class.new(DummyWorker, options) }
+
+      let(:options) { { ack_wait_limit: 60 } }
 
       # DummyWorker class to use in tests
       class DummyWorker

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -55,7 +55,16 @@ module Upperkut
         end
       end
 
-      describe '#latency' do
+      describe '#clear' do
+        it 'deletes the queue' do
+          strategy.push_items(['event' => 'open'])
+          expect do
+            strategy.clear
+          end.to change { strategy.metrics['size'] }.from(1).to(0)
+        end
+      end
+
+      describe '#metrics' do
         it 'returns correct latency' do
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
           strategy.push_items('event' => 'open', 'k' => 1)
@@ -66,15 +75,6 @@ module Upperkut
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:10'))
 
           expect(strategy.metrics['latency']).to eq 10.0
-        end
-      end
-
-      describe '#clear' do
-        it 'deletes the queue' do
-          strategy.push_items(['event' => 'open'])
-          expect do
-            strategy.clear
-          end.to change { strategy.metrics['size'] }.from(1).to(0)
         end
       end
     end

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -66,14 +66,13 @@ module Upperkut
 
       describe '#metrics' do
         it 'returns correct latency' do
-          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
+          travel_to(Time.parse('2015-01-01 00:00:00'))
           strategy.push_items('event' => 'open', 'k' => 1)
 
-          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:04'))
+          travel_to(Time.parse('2015-01-01 00:00:04'))
           strategy.push_items('event' => 'open', 'k' => 1)
 
-          allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:10'))
-
+          travel_to(Time.parse('2015-01-01 00:00:10'))
           expect(strategy.metrics['latency']).to eq 10.0
         end
       end

--- a/spec/upperkut/strategies/buffered_queue_spec.rb
+++ b/spec/upperkut/strategies/buffered_queue_spec.rb
@@ -53,6 +53,27 @@ module Upperkut
 
           expect(items).to eq([{ 'event' => 'open' }, { 'event' => 'click' }])
         end
+
+        it 'fetches old unacknowledged items' do
+          items = []
+
+          travel_to(Time.parse('2015-01-01 00:00:00'))
+          strategy.push_items({ 'event' => 'open' })
+          strategy.push_items({ 'event' => 'open' })
+          items << strategy.fetch_items.map(&:body)
+
+          travel_to(Time.parse('2015-01-01 00:00:10'))
+          items << strategy.fetch_items.map(&:body)
+
+          travel_to(Time.parse('2015-01-01 00:01:10'))
+          items << strategy.fetch_items.map(&:body)
+
+          expect(items).to eq([
+            [{ 'event' => 'open' }, { 'event' => 'open' }],
+            [],
+            [{ 'event' => 'open' }, { 'event' => 'open' }]
+          ])
+        end
       end
 
       describe '#clear' do

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -66,6 +66,23 @@ module Upperkut
         end
       end
 
+      describe '#nack' do
+        before do
+          travel_to(Time.parse('2015-01-01 00:00:00'))
+
+          strategy.push_items([
+            { 'event' => 'open' },
+            { 'event' => 'click' }
+          ])
+        end
+
+        it 'add items back on the queue' do
+          items = strategy.fetch_items
+
+          expect { strategy.nack(items) }.to change { strategy.metrics['size'] }.from(0).to(2)
+        end
+      end
+
       describe '#metrics' do
         it 'returns the number of items to be processed' do
           strategy.push_items([

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -26,7 +26,7 @@ module Upperkut
         strategy.clear
       end
 
-      describe '.push_items' do
+      describe '#push_items' do
         it 'avoids contiguous priority keys' do
           strategy.push_items([
             {'tenant_id' => 1, 'some_text' => 'item 1.1'},
@@ -56,7 +56,7 @@ module Upperkut
         end
       end
 
-      describe '.clear' do
+      describe '#clear' do
         it 'deletes the queue' do
           strategy.push_items(['tenant_id' => 1, 'event' => 'open'])
 
@@ -66,7 +66,7 @@ module Upperkut
         end
       end
 
-      describe '.metrics' do
+      describe '#metrics' do
         it 'returns the number of items to be processed' do
           strategy.push_items([
             {'tenant_id' => 1, 'some_text' => 'item 1.1'},

--- a/spec/upperkut/strategies/scheduled_queue_spec.rb
+++ b/spec/upperkut/strategies/scheduled_queue_spec.rb
@@ -124,7 +124,16 @@ module Upperkut
         end
       end
 
-      describe '#latency' do
+      describe '#clear' do
+        it 'deletes the queue' do
+          strategy.push_items(['event' => 'open'])
+          expect do
+            strategy.clear
+          end.to change { strategy.metrics['size'] }.from(1).to(0)
+        end
+      end
+
+      describe '#metrics' do
         it 'returns correct latency' do
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
           strategy.push_items('event' => 'open', 'k' => 1)
@@ -135,15 +144,6 @@ module Upperkut
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:10'))
 
           expect(strategy.metrics['latency']).to eq 10.0
-        end
-      end
-
-      describe '#clear' do
-        it 'deletes the queue' do
-          strategy.push_items(['event' => 'open'])
-          expect do
-            strategy.clear
-          end.to change { strategy.metrics['size'] }.from(1).to(0)
         end
       end
     end

--- a/spec/upperkut/strategies/scheduled_queue_spec.rb
+++ b/spec/upperkut/strategies/scheduled_queue_spec.rb
@@ -133,6 +133,23 @@ module Upperkut
         end
       end
 
+      describe '#nack' do
+        before do
+          travel_to(Time.parse('2015-01-01 00:00:00'))
+
+          strategy.push_items([
+            { 'event' => 'open' },
+            { 'event' => 'click' }
+          ])
+        end
+
+        it 'add items back on the queue' do
+          items = strategy.fetch_items
+
+          expect { strategy.nack(items) }.to change { strategy.metrics['size'] }.from(0).to(2)
+        end
+      end
+
       describe '#metrics' do
         it 'returns correct latency' do
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))

--- a/spec/upperkut/strategies/scheduled_queue_spec.rb
+++ b/spec/upperkut/strategies/scheduled_queue_spec.rb
@@ -16,7 +16,7 @@ module Upperkut
         strategy.clear
       end
 
-      describe '.push_items' do
+      describe '#push_items' do
         describe 'when there is no item to push' do
           it 'returns false' do
             expect( strategy.push_items ).to be(false)
@@ -54,7 +54,7 @@ module Upperkut
         end
       end
 
-      describe '.fetch_items' do
+      describe '#fetch_items' do
         context 'when the queue is empty' do
           it 'returns empty array' do
             expect(strategy.fetch_items).to eq([])
@@ -70,11 +70,11 @@ module Upperkut
                  { 'event' => 'click', 'timestamp' => timestamp }]
               )
               items = strategy.fetch_items
-              
+
               expect(items).to eq([])
             end
           end
-  
+
           context 'when there are items to pull now and in the future' do
             it 'returns only the present items' do
               timestamp = Time.new(2200).to_i
@@ -83,7 +83,7 @@ module Upperkut
                  { 'event' => 'click', 'timestamp' => timestamp }]
               )
               items = strategy.fetch_items
-              
+
               expect(items.count).to eq(1)
             end
           end
@@ -100,7 +100,7 @@ module Upperkut
                 { 'event' => 'write'},]
               )
               items = strategy.fetch_items
-              
+
               expect(items.count).to eq(2)
             end
           end
@@ -117,14 +117,14 @@ module Upperkut
                 { 'event' => 'write'},]
               )
               items = strategy.fetch_items
-              
+
               expect(items.count).to eq(4)
             end
           end
         end
       end
 
-      describe '.latency' do
+      describe '#latency' do
         it 'returns correct latency' do
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:00'))
           strategy.push_items('event' => 'open', 'k' => 1)
@@ -138,7 +138,7 @@ module Upperkut
         end
       end
 
-      describe '.clear' do
+      describe '#clear' do
         it 'deletes the queue' do
           strategy.push_items(['event' => 'open'])
           expect do


### PR DESCRIPTION
Fixes https://github.com/ResultadosDigitais/upperkut/issues/61.

Items are stored in memory upon retrieval and rely on the network status and on the strategy underlying storage backend to have enough disk space to succeed in pushing items back to the queue. If any of these conditions are not met, items won't be able to get back to the queue and we'll lose them.

The same applies to interruption signals. A worker won't be able to push items back to the queue when it receives a sigkill.

## Solution

Add the concept of acknowledgment. A fetched item now has a time limit to be acknowledged or it will come back to the queue as soon as someone requests new items.