### PR TITLE
Fix items sorting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     fivemat (1.3.7)
     json (2.3.0)
     method_source (1.0.0)
-    pry (0.13.0)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.1)

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -7,8 +7,8 @@ module Upperkut
     def initialize(body:, id: nil, enqueued_at: nil)
       raise ArgumentError, 'Body should be a Hash' unless body.is_a?(Hash)
 
+      @body = body
       @id = id || SecureRandom.uuid
-      @body = body.transform_keys(&:to_s)
       @enqueued_at = enqueued_at || Time.now.utc.to_i
     end
 
@@ -33,8 +33,9 @@ module Upperkut
     end
 
     def self.from_json(item_json)
-      hash = JSON.parse(item_json, symbolize_names: true)
-      new(hash.slice(:id, :body, :enqueued_at))
+      hash = JSON.parse(item_json)
+      id, body, enqueued_at = hash.values_at('id', 'body', 'enqueued_at')
+      new(id: id, body: body, enqueued_at: enqueued_at)
     end
   end
 end

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -1,11 +1,14 @@
+require 'securerandom'
+
 module Upperkut
   class Item
-    attr_reader :enqueued_at
+    attr_reader :id, :body, :enqueued_at
 
-    def initialize(body, enqueued_at = nil)
+    def initialize(body:, id: nil, enqueued_at: nil)
       raise ArgumentError, 'Body should be a Hash' unless body.is_a?(Hash)
 
-      @body = body
+      @id = id || SecureRandom.uuid
+      @body = body.transform_keys(&:to_s)
       @enqueued_at = enqueued_at || Time.now.utc.to_i
     end
 
@@ -21,20 +24,17 @@ module Upperkut
       @body.key?(key)
     end
 
-    def body
-      @body
-    end
-
     def to_json
       JSON.generate(
+        'id' => @id,
         'body' => @body,
         'enqueued_at' => @enqueued_at
       )
     end
 
     def self.from_json(item_json)
-      hash = JSON.parse(item_json)
-      new(hash['body'], hash['enqueued_at'])
+      hash = JSON.parse(item_json, symbolize_names: true)
+      new(hash.slice(:id, :body, :enqueued_at))
     end
   end
 end

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -27,7 +27,7 @@ module Upperkut
       items.map do |item|
         next item if item.is_a?(Item)
 
-        Item.new(item)
+        Item.new(body: item)
       end
     end
 

--- a/spec/upperkut/item_spec.rb
+++ b/spec/upperkut/item_spec.rb
@@ -3,7 +3,13 @@ require 'upperkut/item'
 
 module Upperkut
   RSpec.describe Item do
-    subject(:item) { described_class.new({ my_property: 1 }, current_timestamp) }
+    subject(:item) do
+      described_class.new(
+        id: 'my-unique-id',
+        enqueued_at: current_timestamp,
+        body: { my_property: 1 },
+      )
+    end
 
     let(:current_timestamp) { Time.now.utc.to_i }
 
@@ -26,7 +32,7 @@ module Upperkut
     describe '#body' do
       subject(:body) { item.body }
 
-      it { is_expected.to eq({ my_property: 1 }) }
+      it { is_expected.to eq({ 'my_property' => 1 }) }
     end
 
     describe '#enqueued_at' do
@@ -40,7 +46,8 @@ module Upperkut
 
       it do
         expected_hash = {
-          body: { my_property: 1 },
+          id: 'my-unique-id',
+          body: { 'my_property' => 1 },
           enqueued_at: current_timestamp,
         }
 

--- a/spec/upperkut/item_spec.rb
+++ b/spec/upperkut/item_spec.rb
@@ -7,7 +7,7 @@ module Upperkut
       described_class.new(
         id: 'my-unique-id',
         enqueued_at: current_timestamp,
-        body: { my_property: 1 },
+        body: { 'my_property' => 1 },
       )
     end
 

--- a/spec/upperkut/processor_spec.rb
+++ b/spec/upperkut/processor_spec.rb
@@ -113,7 +113,7 @@ module Upperkut
           end
 
           it 'keeps the same latency' do
-            item = Item.new({ 'id' => '1', 'event' => 'open' }, 2)
+            item = Item.new(body: { 'id' => '1', 'event' => 'open' }, enqueued_at: 2)
             worker.push_items(item)
 
             expect {

--- a/spec/upperkut/util_spec.rb
+++ b/spec/upperkut/util_spec.rb
@@ -24,7 +24,7 @@ module Upperkut
       end
 
       it 'knows how to handle an Item class' do
-        items = Item.new('my_property' => 1)
+        items = Item.new(body: { 'my_property' => 1 })
         normalized_items = normalize_items([ items ])
 
         expect(normalized_items.map(&:body)).to eq(
@@ -33,7 +33,7 @@ module Upperkut
       end
 
       it 'knows how to handle a single Item class' do
-        items = Item.new('my_property' => 1)
+        items = Item.new(body: { 'my_property' => 1 })
         normalized_items = normalize_items(items)
 
         expect(normalized_items.map(&:body)).to eq(


### PR DESCRIPTION
Some strategies rely on Redis to enqueue items, and so, on data structures to implement the strategy algorithm.

Priority queues use sorted sets to implement its algorithm, and we just figured out some characteristics of this data structure causing undesired behavior. They are:
1. Items with the same score are sorted lexicographically, which means, they'll not preserve enqueue order.
2. Sets are meant to store unique values, but we don't want to deduplicate enqueued items.

This PR introduces a unique identifier to every item and uses enqueue order as a score tiebreaker.