### PR TITLE
Process items

### DIFF
--- a/lib/upperkut/processor.rb
+++ b/lib/upperkut/processor.rb
@@ -13,7 +13,7 @@ module Upperkut
       items = @worker.fetch_items.freeze
 
       @worker.server_middlewares.invoke(@worker, items) do
-        @worker_instance.perform(items)
+        @worker_instance.perform(items.map(&:dup))
       end
 
       @strategy.ack(items)

--- a/lib/upperkut/processor.rb
+++ b/lib/upperkut/processor.rb
@@ -11,10 +11,9 @@ module Upperkut
 
     def process
       items = @worker.fetch_items.freeze
-      items_body = items.map(&:body)
 
       @worker.server_middlewares.invoke(@worker, items) do
-        @worker_instance.perform(items_body.dup)
+        @worker_instance.perform(items)
       end
 
       @strategy.ack(items)
@@ -28,7 +27,7 @@ module Upperkut
 
       if items
         if @worker_instance.respond_to?(:handle_error)
-          @worker_instance.handle_error(error, items_body)
+          @worker_instance.handle_error(error, items)
           return
         end
 


### PR DESCRIPTION
We need the `Item` object in order #ack or #nack. Sending to #perform an Item instead of its body also enables workers to access some items metadata, like its enqueued timestamp and retry count.