### PR TITLE
Simplifies ack interface

### DIFF
--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -2,8 +2,6 @@ require 'securerandom'
 
 module Upperkut
   class Item
-    class InvalidStateTransition < RuntimeError; end
-
     attr_reader :id, :body, :enqueued_at
 
     def initialize(body:, id: nil, enqueued_at: nil)

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -27,26 +27,12 @@ module Upperkut
       @body.key?(key)
     end
 
-    def ack
-      raise InvalidStateTransition, 'Item was already accepted' if accepted?
-      @acked = true
-    end
-
-    def acked?
-      @acked
-    end
-
     def nack
-      raise InvalidStateTransition, 'Item was already accepted' if accepted?
       @nacked = true
     end
 
     def nacked?
       @nacked
-    end
-
-    def accepted?
-      acked? || nacked?
     end
 
     def to_json

--- a/spec/upperkut/item_spec.rb
+++ b/spec/upperkut/item_spec.rb
@@ -61,14 +61,6 @@ module Upperkut
       it 'marks a item as acknowledged' do
         expect { item.nack }.to change { item.nacked? }.to(true)
       end
-
-      context 'when the item was previously nacked' do
-        before { item.nack }
-
-        it 'raises an error' do
-          expect { item.nack }.to raise_error(described_class::InvalidStateTransition)
-        end
-      end
     end
 
     describe '#nacked?' do

--- a/spec/upperkut/item_spec.rb
+++ b/spec/upperkut/item_spec.rb
@@ -57,34 +57,6 @@ module Upperkut
       end
     end
 
-    describe '#ack' do
-      it 'marks a item as acknowledged' do
-        expect { item.ack }.to change { item.acked? }.to(true)
-      end
-
-      context 'when the item was previously nacked' do
-        before { item.ack }
-
-        it 'raises an error' do
-          expect { item.ack }.to raise_error(described_class::InvalidStateTransition)
-        end
-      end
-    end
-
-    describe '#acked?' do
-      subject { item.acked? }
-
-      context 'when the item is not nacked' do
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when the item is nacked' do
-        before { item.ack }
-
-        it { is_expected.to be_truthy }
-      end
-    end
-
     describe '#nack' do
       it 'marks a item as acknowledged' do
         expect { item.nack }.to change { item.nacked? }.to(true)
@@ -101,30 +73,6 @@ module Upperkut
 
     describe '#nacked?' do
       subject { item.nacked? }
-
-      context 'when the item is not nacked' do
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when the item is nacked' do
-        before { item.nack }
-
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    describe '#accepted?' do
-      subject { item.accepted? }
-
-      context 'when the item is not acked' do
-        it { is_expected.to be_falsey }
-      end
-
-      context 'when the item is acked' do
-        before { item.ack }
-
-        it { is_expected.to be_truthy }
-      end
 
       context 'when the item is not nacked' do
         it { is_expected.to be_falsey }


### PR DESCRIPTION
Introduces some interface simplifications to make it easier to work with message acknowledgment:

- Eliminates the possibility of partial ack, where despite failing to perform some messages could be "acked"
- Removes the property "acked" from `Upperkut::Item`, since an item will be acked when it was not nacked by the worker's `#perform`.
- Nacks every message marked as `nacked` after a `#perform` invocation so the worker don't have to do it itself.