### PR TITLE
Remove json and hash coupling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 gem 'fivemat'
 gem 'pry'
 gem 'rspec_junit_formatter'
-gem 'simplecov', require: false
+gem 'simplecov', '~> 0.17', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 gem 'fivemat'
 gem 'pry'
 gem 'rspec_junit_formatter'
-gem 'simplecov', '~> 0.17', require: false
+gem 'simplecov', '< 0.18', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     diff-lcs (1.4.4)
     docile (1.3.2)
     fivemat (1.3.7)
+    json (2.3.1)
     method_source (1.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -34,10 +35,11 @@ GEM
     rspec-support (3.9.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
@@ -49,7 +51,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter
-  simplecov
+  simplecov (< 0.18)
   upperkut!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
+    coderay (1.1.3)
     connection_pool (2.2.3)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     docile (1.3.2)
     fivemat (1.3.7)
-    json (2.3.0)
     method_source (1.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -24,22 +23,21 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-expectations (3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
+    rspec-support (3.9.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (0.17.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
 
 PLATFORMS
   ruby
@@ -55,4 +53,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   2.1.4
+   1.16.6

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -4,9 +4,9 @@ module Upperkut
   class Item
     attr_reader :id, :body, :enqueued_at
 
-    def initialize(body:, id: nil, enqueued_at: nil)
-      @body = body
-      @id = id || SecureRandom.uuid
+    def initialize(id:, body:, enqueued_at: nil)
+      @id = id
+      @body = body.transform_keys(&:to_s)
       @enqueued_at = enqueued_at || Time.now.utc.to_i
       @nacked = false
     end

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -5,14 +5,8 @@ module Upperkut
     attr_reader :id, :body, :enqueued_at
 
     def initialize(id:, body:, enqueued_at: nil)
-      normalized_body = if body.is_a?(Hash)
-                body.transform_keys(&:to_s)
-              else
-                body
-              end
-
       @id = id
-      @body = normalized_body
+      @body = body
       @enqueued_at = enqueued_at || Time.now.utc.to_i
       @nacked = false
     end

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -5,24 +5,10 @@ module Upperkut
     attr_reader :id, :body, :enqueued_at
 
     def initialize(body:, id: nil, enqueued_at: nil)
-      raise ArgumentError, 'Body should be a Hash' unless body.is_a?(Hash)
-
       @body = body
       @id = id || SecureRandom.uuid
       @enqueued_at = enqueued_at || Time.now.utc.to_i
       @nacked = false
-    end
-
-    def [](key)
-      @body[key]
-    end
-
-    def []=(key, value)
-      @body[key] = value
-    end
-
-    def key?(key)
-      @body.key?(key)
     end
 
     def nack
@@ -31,20 +17,6 @@ module Upperkut
 
     def nacked?
       @nacked
-    end
-
-    def to_json
-      JSON.generate(
-        'id' => @id,
-        'body' => @body,
-        'enqueued_at' => @enqueued_at
-      )
-    end
-
-    def self.from_json(item_json)
-      hash = JSON.parse(item_json)
-      id, body, enqueued_at = hash.values_at('id', 'body', 'enqueued_at')
-      new(id: id, body: body, enqueued_at: enqueued_at)
     end
   end
 end

--- a/lib/upperkut/item.rb
+++ b/lib/upperkut/item.rb
@@ -5,8 +5,14 @@ module Upperkut
     attr_reader :id, :body, :enqueued_at
 
     def initialize(id:, body:, enqueued_at: nil)
+      normalized_body = if body.is_a?(Hash)
+                body.transform_keys(&:to_s)
+              else
+                body
+              end
+
       @id = id
-      @body = body.transform_keys(&:to_s)
+      @body = normalized_body
       @enqueued_at = enqueued_at || Time.now.utc.to_i
       @nacked = false
     end

--- a/lib/upperkut/strategies/buffered_queue.rb
+++ b/lib/upperkut/strategies/buffered_queue.rb
@@ -83,7 +83,7 @@ module Upperkut
         return false if items.empty?
 
         redis do |conn|
-          conn.rpush(key, items.map(&:to_json))
+          conn.rpush(key, encode_json_items(items))
         end
 
         true
@@ -111,7 +111,7 @@ module Upperkut
         redis do |conn|
           conn.eval(ACK_ITEMS,
                     keys: [processing_key],
-                    argv: items.map(&:to_json))
+                    argv: encode_json_items(items))
         end
       end
 
@@ -121,7 +121,7 @@ module Upperkut
         redis do |conn|
           conn.eval(NACK_ITEMS,
                     keys: [key, processing_key],
-                    argv: items.map(&:to_json))
+                    argv: encode_json_items(items))
         end
       end
 

--- a/lib/upperkut/strategies/priority_queue.rb
+++ b/lib/upperkut/strategies/priority_queue.rb
@@ -112,7 +112,7 @@ module Upperkut
 
             conn.eval(ENQUEUE_ITEM,
                       keys: keys,
-                      argv: [item.to_json])
+                      argv: [encode_json_items(item)])
           end
         end
 

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -126,14 +126,14 @@ module Upperkut
 
       def latency
         now = Time.now.utc
-        now_timestamp = now.to_f
+        timestamp = now.to_f
 
         item = redis do |conn|
-          item = conn.zrangebyscore(key, '-inf'.freeze, now_timestamp.to_s, limit: [0, 1]).first
+          item = conn.zrangebyscore(key, '-inf', timestamp.to_s, limit: [0, 1]).first
           decode_json_items([item]).first
         end
 
-        return now_timestamp - item.body['timestamp'].to_f if item
+        return timestamp - item.body['timestamp'].to_f if item
         0
       end
 

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -43,8 +43,8 @@ module Upperkut
 
         redis do |conn|
           items.each do |item|
-            ensure_timestamp_attr(item)
-            conn.zadd(key, item['timestamp'], item.to_json)
+            schedule_item = ensure_timestamp_attr(item)
+            conn.zadd(key, schedule_item.body['timestamp'], encode_json_items(schedule_item))
           end
         end
 

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -126,16 +126,14 @@ module Upperkut
       def latency
         now = Time.now.utc
         now_timestamp = now.to_f
-        item = nil
 
-        redis do |conn|
+        item = redis do |conn|
           item = conn.zrangebyscore(key, '-inf'.freeze, now_timestamp.to_s, limit: [0, 1]).first
-          item = decode_json_items([item]).first
+          decode_json_items([item]).first
         end
 
-        return 0 unless item
-
-        now_timestamp - item.body['timestamp'].to_f
+        return now_timestamp - item.body['timestamp'].to_f if item
+        0
       end
 
       def redis

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -44,7 +44,8 @@ module Upperkut
         redis do |conn|
           items.each do |item|
             schedule_item = ensure_timestamp_attr(item)
-            conn.zadd(key, schedule_item.body['timestamp'], encode_json_items(schedule_item))
+            timestamp = schedule_item.body['timestamp']
+            conn.zadd(key, timestamp, encode_json_items(schedule_item))
           end
         end
 

--- a/lib/upperkut/strategies/scheduled_queue.rb
+++ b/lib/upperkut/strategies/scheduled_queue.rb
@@ -134,6 +134,7 @@ module Upperkut
         end
 
         return timestamp - item.body['timestamp'].to_f if item
+
         0
       end
 

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -47,8 +47,9 @@ module Upperkut
       items.each_with_object([]) do |item_json, memo|
         next unless item_json
 
-        hash = JSON.parse(item_json, symbolize_names: true)
-        memo << Item.new(hash.slice(:id, :body, :enqueued_at))
+        hash = JSON.parse(item_json)
+        id, body, enqueued_at = hash.values_at('id', 'body', 'enqueued_at')
+        memo << Item.new(id: id, body: body, enqueued_at: enqueued_at)
       end
     end
 

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -38,7 +38,7 @@ module Upperkut
         JSON.generate(
           'id' => item.id,
           'body' => item.body,
-          'enqueued_at' => item.enqueued_at,
+          'enqueued_at' => item.enqueued_at
         )
       end
     end

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -27,13 +27,28 @@ module Upperkut
       items.map do |item|
         next item if item.is_a?(Item)
 
-        Item.new(body: item)
+        Item.new(id: SecureRandom.uuid, body: item)
+      end
+    end
+
+    def encode_json_items(items)
+      items = [items] unless items.is_a?(Array)
+
+      items.map do |item|
+        JSON.generate(
+          'id' => item.id,
+          'body' => item.body,
+          'enqueued_at' => item.enqueued_at,
+        )
       end
     end
 
     def decode_json_items(items)
-      items.each_with_object([]) do |item, memo|
-        memo << Item.from_json(item) if item
+      items.each_with_object([]) do |item_json, memo|
+        next unless item_json
+
+        hash = JSON.parse(item_json, symbolize_names: true)
+        memo << Item.new(hash.slice(:id, :body, :enqueued_at))
       end
     end
 

--- a/spec/upperkut/item_spec.rb
+++ b/spec/upperkut/item_spec.rb
@@ -13,12 +13,6 @@ module Upperkut
 
     let(:current_timestamp) { Time.now.utc.to_i }
 
-    it 'allows accessing body properties like a hash' do
-      item[:my_another_property] = 2
-
-      expect(item[:my_another_property]).to eq(2)
-    end
-
     describe '#initialize' do
       context 'when the enqueued at is not informed' do
         let(:current_timestamp) { nil }
@@ -41,22 +35,6 @@ module Upperkut
       it { is_expected.to eq(current_timestamp) }
     end
 
-    describe '#key?' do
-      subject { item.key?(key) }
-
-      context 'when the key is present in the body' do
-        let(:key) { 'my_property' }
-
-        it { is_expected.to be_truthy }
-      end
-
-      context 'when the key is not present in the body' do
-        let(:key) { 'my_inexistent_property' }
-
-        it { is_expected.to be_falsey }
-      end
-    end
-
     describe '#nack' do
       it 'marks a item as acknowledged' do
         expect { item.nack }.to change { item.nacked? }.to(true)
@@ -74,39 +52,6 @@ module Upperkut
         before { item.nack }
 
         it { is_expected.to be_truthy }
-      end
-    end
-
-    describe '#to_json' do
-      subject { item.to_json }
-
-      it do
-        expected_hash = {
-          id: 'my-unique-id',
-          body: { 'my_property' => 1 },
-          enqueued_at: current_timestamp,
-        }
-
-        is_expected.to eq(expected_hash.to_json)
-      end
-    end
-
-    describe '.from_json' do
-      subject(:unserialized_item) { described_class.from_json(item_json) }
-
-      let(:item_json) do
-        {
-          body: { my_property: 1 },
-          enqueued_at: current_timestamp,
-        }.to_json
-      end
-
-      it 'fetches the item body from the json' do
-        expect(unserialized_item.body).to eq({ 'my_property' => 1 })
-      end
-
-      it 'fetches the item enqueued_at from the json' do
-        expect(unserialized_item.enqueued_at).to eq(current_timestamp)
       end
     end
   end

--- a/spec/upperkut/processor_spec.rb
+++ b/spec/upperkut/processor_spec.rb
@@ -33,13 +33,13 @@ module Upperkut
     describe '#process' do
       before do
         allow_any_instance_of(worker).to receive(:perform) do |_instance, items|
-          items.select { |item| item['event'] == 'will_ack' }
+          items.select { |item| item.body['event'] == 'will_ack' }
         end
       end
 
       it 'acknowledges performed and not-acknowledged items' do
         item_1 = { 'id' => '1', 'event' => 'open' }
-        item_2 = Item.new(body: { 'id' => '2', 'event' => 'will_ack' })
+        item_2 = Item.new(id: '1', body: { 'id' => '2', 'event' => 'will_ack' })
         worker.push_items([ item_1, item_2 ])
 
         item_2.nack
@@ -74,7 +74,7 @@ module Upperkut
       context 'when something goes wrong while processing' do
         before do
           allow_any_instance_of(worker).to receive(:perform) do |_instance, items|
-            items.select { |item| item['event'] == 'will_nack' }.each(&:nack)
+            items.select { |item| item.body['event'] == 'will_nack' }.each(&:nack)
             raise ArgumentError
           end
         end
@@ -115,7 +115,7 @@ module Upperkut
           end
 
           it 'keeps the same latency' do
-            item = Item.new(body: { 'id' => '1', 'event' => 'open' }, enqueued_at: 2)
+            item = Item.new(id: '1', body: { 'id' => '1', 'event' => 'open' }, enqueued_at: 2)
             worker.push_items(item)
 
             expect {

--- a/spec/upperkut/strategies/priority_queue_spec.rb
+++ b/spec/upperkut/strategies/priority_queue_spec.rb
@@ -16,7 +16,7 @@ module Upperkut
 
       subject(:strategy) do
         options = {
-          priority_key: lambda { |item| item['tenant_id'] }
+          priority_key: lambda { |item| item.body['tenant_id'] }
         }
 
         described_class.new(DummyWorker, options)

--- a/spec/upperkut/strategies/scheduled_queue_spec.rb
+++ b/spec/upperkut/strategies/scheduled_queue_spec.rb
@@ -159,7 +159,6 @@ module Upperkut
           strategy.push_items('event' => 'open', 'k' => 1)
 
           allow(Time).to receive(:now).and_return(Time.parse('2015-01-01 00:00:10'))
-
           expect(strategy.metrics['latency']).to eq 10.0
         end
       end

--- a/spec/upperkut/util_spec.rb
+++ b/spec/upperkut/util_spec.rb
@@ -24,7 +24,7 @@ module Upperkut
       end
 
       it 'knows how to handle an Item class' do
-        items = Item.new(body: { 'my_property' => 1 })
+        items = Item.new(id: '1', body: { 'my_property' => 1 })
         normalized_items = normalize_items([ items ])
 
         expect(normalized_items.map(&:body)).to eq(
@@ -33,7 +33,7 @@ module Upperkut
       end
 
       it 'knows how to handle a single Item class' do
-        items = Item.new(body: { 'my_property' => 1 })
+        items = Item.new(id: '1', body: { 'my_property' => 1 })
         normalized_items = normalize_items(items)
 
         expect(normalized_items.map(&:body)).to eq(
@@ -45,7 +45,7 @@ module Upperkut
     describe '#decode_json_items' do
       context 'when collection has nil values' do
         it 'rejects nil and preserve collection' do
-          items_json = [nil, nil, nil, '{"body":{"id":2,"name":"value"}}']
+          items_json = [nil, nil, nil, '{"id":"my-job","body":{"id":2,"name":"value"}}']
           items = decode_json_items(items_json).map(&:body)
 
           expect(items).to eq(


### PR DESCRIPTION
Hello!

Just started working on a Cloud Pubsub strategy and noticed several points where we are heavily coupled to the idea of a `Hash` as the `Item` body and JSON serialization, which became a problem when we tried to add protobuf support.

On this PR we remove this coupling.