### PR TITLE
Prevent perform from being called without items

### DIFF
--- a/lib/upperkut/processor.rb
+++ b/lib/upperkut/processor.rb
@@ -11,6 +11,7 @@ module Upperkut
 
     def process
       items = @worker.fetch_items.freeze
+      return unless items.any?
 
       @worker.server_middlewares.invoke(@worker, items) do
         @worker_instance.perform(items)

--- a/spec/upperkut/processor_spec.rb
+++ b/spec/upperkut/processor_spec.rb
@@ -49,6 +49,16 @@ module Upperkut
         ])
       end
 
+      context 'when there is no items to process' do
+        before do
+          allow(worker).to receive(:fetch_items).and_return([])
+        end
+
+        it 'does not call the worker' do
+          expect(worker).not_to receive(:perform)
+        end
+      end
+
       context 'when something goes wrong while fetching items' do
         let(:logger) { spy('logger') }
 


### PR DESCRIPTION
Hello :octocat: 

Not every strategy should be forced to analyze the queue size before calling `#process` (imagine that communication with the queue is cost-intensive and you don't want to do it two times per cycle), so there is some situations where `#process` is called without any item to fetch. In this case, it is better to stop execution before calling the middlewares and the worker, since there's nothing for them to do.