### PR TITLE
Add support to decimal global polling interval

### DIFF
--- a/lib/upperkut.rb
+++ b/lib/upperkut.rb
@@ -58,7 +58,7 @@ module Upperkut
 
     def self.default
       new.tap do |config|
-        config.polling_interval = Integer(ENV['UPPERKUT_POLLING_INTERVAL'] || 5)
+        config.polling_interval = Float(ENV['UPPERKUT_POLLING_INTERVAL'] || 5)
       end
     end
 


### PR DESCRIPTION
An integer polling interval may not be enough for some applications aiming for sub-second latencies. We can currently work around this issue by specifying a `polling_interval` on every worker to force a decimal value, but it is not practical.

On this PR we make it possible to define a global decimal polling interval.