### PR TITLE
Class#name returns a frozen string on ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.4.4
+      - image: circleci/ruby:2.7.2
         environment:
           CC_TEST_REPORTER_ID: 03ab83a772148a577d29d4acf438d7ebdc95c632224122d0ba8dbb291eedebe6
           COVERAGE: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/lib/upperkut/util.rb
+++ b/lib/upperkut/util.rb
@@ -4,7 +4,7 @@ require 'upperkut/item'
 module Upperkut
   module Util
     def to_underscore(object)
-      klass_name = object
+      klass_name = object.dup
       klass_name.gsub!(/::/, '_')
       klass_name.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
       klass_name.gsub!(/([a-z\d])([A-Z])/, '\1_\2')

--- a/spec/upperkut/util_spec.rb
+++ b/spec/upperkut/util_spec.rb
@@ -4,6 +4,16 @@ module Upperkut
   RSpec.describe Util do
     include Upperkut::Util
 
+    describe '#to_underscore' do
+      it 'transforms strings into their underscored version' do
+        expect(to_underscore("Upperkut::BufferedQueue")).to eq('upperkut_buffered_queue')
+      end
+
+      it 'transforms frozen strings into their underscored version properly' do
+        expect(to_underscore(Upperkut::Util.name)).to eq('upperkut_util')
+      end
+    end
+
     describe '#normalize_items' do
       it 'transforms hashes into items' do
         items_hash = [{ 'my_property' => 1 }]


### PR DESCRIPTION
to_underscore mutates the string.

We can either dup the object on to_underscode itself or pass unfrozen strings to it. I'm fine either way. 