### PR TITLE
add catalog-info file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: upperkut
   description: Ferramenta de processamento em segundo plano para Ruby.
   annotations:
+    circleci.com/project-slug: github/ResultadosDigitais/upperkut
     github.com/project-slug: ResultadosDigitais/upperkut
   links:
     - url: <https://opensource.resultadosdigitais.com.br/>

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: upperkut
+  description: Ferramenta de processamento em segundo plano para Ruby.
+  annotations:
+    github.com/project-slug: ResultadosDigitais/upperkut
+  links:
+    - url: <https://opensource.resultadosdigitais.com.br/>
+      title: Projetos open source da RD.
+spec:
+  type: service
+  owner: devtools
+  lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,6 +10,6 @@ metadata:
     - url: <https://opensource.resultadosdigitais.com.br/>
       title: Projetos open source da RD.
 spec:
-  type: service
+  type: library
   owner: devtools
   lifecycle: production


### PR DESCRIPTION
Contexto

Estamos mapeando os componentes para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente para que ele seja refletido no Backstage.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md