### PR TITLE
[MKTDEVTOOL-759] Conserta link no catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
     circleci.com/project-slug: github/ResultadosDigitais/upperkut
     github.com/project-slug: ResultadosDigitais/upperkut
   links:
-    - url: <https://opensource.resultadosdigitais.com.br/>
+    - url: https://opensource.resultadosdigitais.com.br/
       title: Projetos open source da RD.
 spec:
   type: library


### PR DESCRIPTION
**Contexto**

Como pode ser visto em https://us5.datadoghq.com/logs?cols=host%2Cservice&event&from_ts=1664885483657&index=&live=true&messageDisplay=inline&query=service%3Abackstage+status%3Awarn+Policy+check+failed+for&stream_sort=time%2Cdesc&to_ts=1664886383657&viz=stream, esse catalog-info está quebrado pois o link possui caracteres proibidos.

**Objetivo**

Conserta o nome removendo caracteres especiais do link