### PR TITLE
[MKTKERNEL-420] Update ruby to 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/ruby: 3.2
+      - image: cimg/ruby:3.2
         environment:
           CC_TEST_REPORTER_ID: 03ab83a772148a577d29d4acf438d7ebdc95c632224122d0ba8dbb291eedebe6
           COVERAGE: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7.2
+      - image: cimg/ruby: 3.2
         environment:
           CC_TEST_REPORTER_ID: 03ab83a772148a577d29d4acf438d7ebdc95c632224122d0ba8dbb291eedebe6
           COVERAGE: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,73 @@
+AllCops:
+  Exclude:
+    - 'vendor/**/*'
+    - 'spec/fixtures/**/*'
+    - 'tmp/**/*'
+  TargetRubyVersion: 3.2
+
+Naming/PredicateName:
+  MethodDefinitionMacros:
+    - define_method
+    - define_singleton_method
+    - def_node_matcher
+    - def_node_search
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 20
+
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/ClassStructure:
+  Enabled: true
+  Categories:
+    module_inclusion:
+      - include
+      - prepend
+      - extend
+  ExpectedOrder:
+      - module_inclusion
+      - constants
+      - public_class_methods
+      - initializer
+      - instance_methods
+      - protected_methods
+      - private_methods
+
+Layout/TrailingWhitespace:
+  AllowInHeredoc: true
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Lint/InterpolationCheck:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Lint/UselessAccessModifier:
+  MethodCreatingMethods:
+    - 'def_matcher'
+    - 'def_node_matcher'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:3.2
 
 WORKDIR /code
 COPY . .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ DEPENDENCIES
   upperkut!
 
 BUNDLED WITH
-   2.1.4
+   2.4.1

--- a/upperkut.gemspec
+++ b/upperkut.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['upperkut']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2.2'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
   spec.add_dependency 'redis', '>= 4.1.0', '< 5.0.0'


### PR DESCRIPTION
The kernel team is mapping and updating RD's internal gems to use the same ruby version as RDSM.

**To test this PR,** run the command: 

- **sudo apt install redis-server** - 

- **bundle exec rspec**

CODEOWNER: Devtools