### PR TITLE
Atualiza dependabot pra não executar rebase automático

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
   pull-request-branch-name:
     separator: "-"
   open-pull-requests-limit: 10
+  rebase-strategy: disabled


### PR DESCRIPTION
Muda configurações do dependabot pra não executar rebase automático.

Você pode continuar usando o rebase automatizado do dependabot através de comandos por comentários: https://docs.github.com/pt/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#gerenciando-pull-requests-dependabot-com-comandos-de-coment%C3%A1rio
